### PR TITLE
Windows Credentialed Autologin (GlueXML)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_compile_definitions(
   ${PROJECT_NAME}
   PRIVATE CLASSICAPI_VERSION_VALUE=${CLASSICAPI_VERSION_VALUE})
 
-target_link_libraries(${PROJECT_NAME} PRIVATE minhook)
+target_link_libraries(${PROJECT_NAME} PRIVATE minhook advapi32)
 
 target_include_directories(
   ${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ the glue state because GlueXML had no way to reach them otherwise.
 
 | Group | Calls |
 |-------|-------|
+| [Account](docs/API.md#account) | `SaveAccount`, `DeleteAccount`, `GetSavedAccounts`, `LoginWithSavedAccount` (passwords encrypted in Windows Credential Manager, scoped per realmlist; plaintext never returned to Lua) |
 | [CharacterList](docs/API.md#characterlist) | `GetSavedCharacterOrder`, `SetSavedCharacterOrder` (persist to `WTF\Account\...\ClassicAPI.txt`) |
 | CVar | `GetCVar`, `SetCVar`, `RegisterCVar`, `GetCVarDefault`, `C_CVar.GetCVarBool` (storage is process-global — writes from glue are visible in-world and vice versa) |
 | Script | `RunScript` (compile and run a Lua chunk in the glue state's globals — useful for slash-command-style helpers in GlueXML) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -353,15 +353,28 @@ accounts without persisting plaintext passwords to SavedVariables.
   empty, no realmlist is set, or the OS rejects the write.
 - `DeleteAccount(name)` — remove the saved entry. Returns `true` if a
   matching entry existed and was deleted.
-- `GetSavedAccounts()` — returns a numeric-keyed table of account names
-  for the current realmlist. Other realmlists' entries are invisible.
-  Empty table if no realmlist is set.
+- `GetSavedAccounts()` — returns a numeric-keyed table of entries for
+  the current realmlist. Other realmlists' entries are invisible. Empty
+  table if no realmlist is set. Each entry is a table:
+
+  | Field | Type | Notes |
+  |---|---|---|
+  | `name` | string | Account name as saved. |
+  | `lastUsed` | number | Unix epoch seconds of the last write to the vault entry. Refreshed automatically by `LoginWithSavedAccount`, so this functions as a "last used" timestamp. `0` if Windows didn't supply a timestamp (extremely rare, e.g. credentials manually injected). |
+
+  ```lua
+  for i, entry in ipairs(GetSavedAccounts()) do
+      print(entry.name, date("%Y-%m-%d %H:%M", entry.lastUsed))
+  end
+  ```
+
 - `LoginWithSavedAccount(name)` — decrypt internally and feed the
   credentials to the engine's login function. Returns `true` if
   credentials were found and dispatched, `false` if no such entry
   exists. **Plaintext is never returned to Lua.** Equivalent to what
   `DefaultServerLogin(name, password)` does, but with the password
-  fetched from the vault rather than passed in.
+  fetched from the vault rather than passed in. Also re-saves the
+  credential (same value) to refresh the `lastUsed` timestamp.
 
 #### Scoping per realmlist
 
@@ -423,10 +436,12 @@ local function OnLoginClicked()
     end
 end
 
--- Populate a selection list from the vault.
+-- Populate a selection list from the vault, sorted by recency.
 local accounts = GetSavedAccounts()
+table.sort(accounts, function(a, b) return a.lastUsed > b.lastUsed end)
 for i = 1, table.getn(accounts) do
-    print(i, accounts[i])
+    local e = accounts[i]
+    print(i, e.name, "last used:", date("%m/%d/%Y", e.lastUsed))
 end
 
 -- Forget an account.

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,6 +6,9 @@ build instructions.
 
 ## Contents
 
+- [Account](#account)
+  - [`SaveAccount(name, password)` / `DeleteAccount(name)` / `GetSavedAccounts()` / `LoginWithSavedAccount(name)` — GlueXML only](#saveaccountname-password--deleteaccountname--getsavedaccounts--loginwithsavedaccountname--gluexml-only)
+
 - [Action](#action)
   - [`GetActionInfo(slot)`](#getactioninfoslot)
 
@@ -330,6 +333,105 @@ build instructions.
   - [`C_UnitAuras.GetAuraDataBySpellName(unit, spellName [, filter])`](#c_unitaurasgetauradatabyspellnameunit-spellname--filter)
   - [`C_UnitAuras.GetUnitAuras(unit [, filter])`](#c_unitaurasgetunitaurasunit--filter)
   - [`C_UnitAuras.GetAuraDispelTypeColor(dispelName)`](#c_unitaurasgetauradispeltypecolordispelname)
+
+## Account
+
+### `SaveAccount(name, password)` / `DeleteAccount(name)` / `GetSavedAccounts()` / `LoginWithSavedAccount(name)` — GlueXML only
+
+Persists account credentials in Windows Credential Manager (per-user,
+DPAPI-encrypted) and dispatches login from C so the plaintext password
+never crosses the C↔Lua boundary on the way out. Designed for GlueXML
+rewrites of `AccountLogin.lua` that want a selection list of remembered
+accounts without persisting plaintext passwords to SavedVariables.
+
+> **Only callable from the login screen** (the "glue" Lua state).
+> Calling them from an in-world addon errors with "attempt to call nil"
+> — they aren't registered there.
+
+- `SaveAccount(name, password)` — encrypt and save under the current
+  realmlist. Returns `true` on success, `false` if name or password is
+  empty, no realmlist is set, or the OS rejects the write.
+- `DeleteAccount(name)` — remove the saved entry. Returns `true` if a
+  matching entry existed and was deleted.
+- `GetSavedAccounts()` — returns a numeric-keyed table of account names
+  for the current realmlist. Other realmlists' entries are invisible.
+  Empty table if no realmlist is set.
+- `LoginWithSavedAccount(name)` — decrypt internally and feed the
+  credentials to the engine's login function. Returns `true` if
+  credentials were found and dispatched, `false` if no such entry
+  exists. **Plaintext is never returned to Lua.** Equivalent to what
+  `DefaultServerLogin(name, password)` does, but with the password
+  fetched from the vault rather than passed in.
+
+#### Scoping per realmlist
+
+Every operation is scoped by the current `realmList` CVar (the address
+from `realmlist.wtf`, e.g. `"logon.turtle-wow.org"`), not the friendly
+display name. The same account name on two different private servers
+therefore gets two distinct vault entries:
+
+```
+ClassicAPI/WoW/logon.turtle-wow.org/MYACCT
+ClassicAPI/WoW/logon.other-server.com/MYACCT
+```
+
+Switching realmlists changes the visible account list automatically;
+no separate "select realm" step. If you need a refresh while still on
+the login screen, call `Autologin_Load()` (or `GetSavedAccounts()`
+directly) after the realmlist changes.
+
+#### Storage
+
+Entries live in the OS Credential Manager under the
+`ClassicAPI/WoW/<realmlist>/` namespace. Users can inspect and wipe
+them via Windows' `control /name Microsoft.CredentialManager` →
+Generic Credentials, the same way they'd manage any other Windows-
+stored credential.
+
+#### Security caveats
+
+Realistic about what this defends against:
+
+- **Defeats**: casual file inspection of WTF, sharing the WTF folder,
+  cloud-syncing it, another Windows user on the same machine, malware
+  running as a different Windows user.
+- **Does not defeat**: any process running as the current Windows user
+  can decrypt these via DPAPI — it's per-user, not per-process. No
+  "decrypt and return plaintext" path is exposed to Lua, so a hostile
+  addon can trigger a login with a saved account but can't extract the
+  password. Plaintext is also unavoidably in process memory while the
+  engine sends SRP.
+
+#### Addon example
+
+```lua
+-- GlueXML, e.g. AccountLogin.lua: save credentials on first manual
+-- login, one-click login on subsequent shows.
+
+local function OnLoginClicked()
+    local name = AccountLoginAccountEdit:GetText()
+    local password = AccountLoginPasswordEdit:GetText()
+    if not name or name == "" then return end
+
+    if password and password ~= "" then
+        -- Fresh login or password change: persist + log in.
+        SaveAccount(name, password)
+        LoginWithSavedAccount(name)
+    else
+        -- Reuse stored credentials.
+        LoginWithSavedAccount(name)
+    end
+end
+
+-- Populate a selection list from the vault.
+local accounts = GetSavedAccounts()
+for i = 1, table.getn(accounts) do
+    print(i, accounts[i])
+end
+
+-- Forget an account.
+DeleteAccount("OLDACCT")
+```
 
 ## Action
 

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -3139,4 +3139,55 @@ enum Offsets {
     SMSG_OPCODE_MIRROR_TIMER_PAUSE = 0x1DA,
     SMSG_OPCODE_MIRROR_TIMER_STOP = 0x1DB,
     MIRROR_TIMER_SLOT_COUNT = 3,
+
+    // `realmList` CVar reader — returns the configured realmlist
+    // address (e.g. "logon.turtle-wow.org") as a `const char *`, or
+    // NULL when unset. `__fastcall(int forceRefresh)`; pass 0 to read
+    // the cached value (callers in the engine pass non-zero only
+    // around CMSG_AUTH_SESSION reconnects). Lazily registers the CVar
+    // on first call.
+    //
+    // This is the realmlist *address*, not the display name (the
+    // friendly server name visible in the realm-select dialog lives
+    // in the `realmName` CVar at `FUN_005AB7D0`, read by
+    // `Script_GetServerName`). Credentials are scoped on this value
+    // because two different private servers may share the same
+    // friendly name but never the same realmlist address.
+    FUN_CVAR_REALM_LIST = 0x005AB680,
+
+    // Engine login entry — the C function `Script_DefaultServerLogin`
+    // (the glue Lua binding at `0x0046D160`) tail-calls into here with
+    // the account/password as raw C strings. We invoke it directly from
+    // C++ when dispatching a saved-credential login, bypassing the
+    // round-trip through Lua so the plaintext never crosses the
+    // Lua boundary on the way out.
+    //
+    //   __fastcall void(ecx = const char *account, edx = char *password)
+    //
+    // The function:
+    //   1. Gates on three globals — VAR_GLUE_LOGIN_READY1,
+    //      VAR_GLUE_LOGIN_READY2 (both must be nonzero) and
+    //      VAR_GLUE_LOGIN_INPROGRESS (must be zero). All set up by the
+    //      normal glue boot flow; a call made while the AccountLogin
+    //      screen is showing is safe, an off-screen call silently no-ops.
+    //   2. Copies the account into a 0x40-byte buffer at `0x00B41DB0`
+    //      and uppercases it in place.
+    //   3. Fires the "connecting" status event.
+    //   4. Hands the (uppercased account, password) pair to the SRP
+    //      initiator at `FUN_005AB4B0`.
+    //   5. **Zeros the caller's password buffer in place** via an
+    //      unrolled `REP STOSD` loop counting strlen bytes — so the
+    //      decrypted-on-stack buffer we feed in gets scrubbed for free
+    //      after the SRP step consumes it.
+    //   6. Calls into the AddOn-registry init (`FUN_0051C740`) with the
+    //      uppercased account name. Same call documented in CLAUDE.md
+    //      under "AddOn registry & hot-reload".
+    FUN_GLUE_LOGIN_ATTEMPT = 0x0046AFB0,
+
+    // Glue-state readiness flags read by `FUN_GLUE_LOGIN_ATTEMPT`'s
+    // prologue. Names reflect the gate-condition logic, not anything
+    // intrinsic to the engine — the engine just checks `R1 && R2 && !IP`.
+    VAR_GLUE_LOGIN_READY1 = 0x00B41DFC,
+    VAR_GLUE_LOGIN_READY2 = 0x00B41E04,
+    VAR_GLUE_LOGIN_INPROGRESS = 0x00B41DA0,
 };

--- a/src/security/Account.cpp
+++ b/src/security/Account.cpp
@@ -88,8 +88,12 @@ int __fastcall Script_GetSavedAccounts(void *L) {
     Game::Lua::NewTable(L);
     int key = 1;
     for (const auto &acct : accounts) {
+        // Push outer index → inner table { name=..., lastUsed=... }.
         Game::Lua::PushNumber(L, static_cast<double>(key++));
-        Game::Lua::PushString(L, acct.c_str());
+        Game::Lua::NewTable(L);
+        Game::Lua::SetFieldString(L, "name", acct.name.c_str());
+        Game::Lua::SetFieldNumber(L, "lastUsed",
+                                  static_cast<double>(acct.lastUsedUnix));
         Game::Lua::SetTable(L, -3);
     }
     return 1;
@@ -108,6 +112,15 @@ int __fastcall Script_LoginWithSavedAccount(void *L) {
         return 1;
     }
 
+    // Keep a copy of the plaintext on the stack — the engine's login
+    // path zeros the buffer it consumes (see Offsets::FUN_GLUE_LOGIN_ATTEMPT
+    // notes), but we need the plaintext for one more thing: re-saving
+    // the credential so Windows updates LastWritten. Without that,
+    // `lastUsed` in `GetSavedAccounts()` would only reflect the
+    // original `SaveAccount` time, not actual logins.
+    std::vector<char> copyForTouch(password.begin(), password.end());
+    copyForTouch.push_back('\0');
+
     // CredStore::Load gives us a vector sized to the password length
     // with a trailing nul one past the end (resize to len after writing
     // len+1 bytes). The engine login function reads via strlen, so we
@@ -117,12 +130,20 @@ int __fastcall Script_LoginWithSavedAccount(void *L) {
     // after SRP consumes them.
     LoginAttempt(name, password.data());
 
+    // Refresh LastWritten by re-saving the credential. Done after
+    // engine consumes so a no-op call (e.g. glue guards not satisfied)
+    // doesn't update the timestamp on a login that didn't happen.
+    // ... actually, the engine no-ops silently, so we can't gate on
+    // success. We update unconditionally; in practice this only fires
+    // from the AccountLogin screen, which has the guards satisfied.
+    Security::CredStore::Save(name, copyForTouch.data());
+
     // Belt-and-suspenders scrub. Engine already zeroed `password.size()`
     // bytes, but we re-scrub the full vector capacity in case the
-    // engine's wipe assumed an exact strlen match.
-    if (!password.empty()) {
-        SecureZeroMemory(password.data(), password.size());
-    }
+    // engine's wipe assumed an exact strlen match. Also scrub the
+    // touch copy that lived through the engine call.
+    SecureZeroMemory(password.data(), password.size());
+    SecureZeroMemory(copyForTouch.data(), copyForTouch.size());
 
     Game::Lua::PushBool(L, true);
     return 1;

--- a/src/security/Account.cpp
+++ b/src/security/Account.cpp
@@ -1,0 +1,143 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Lesser General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+// Glue-side bindings for the saved-credentials API:
+//
+//   SaveAccount(name, password)        -> bool
+//   DeleteAccount(name)                -> bool
+//   GetSavedAccounts()                 -> { "ACCT1", "ACCT2", ... }
+//   LoginWithSavedAccount(name)        -> bool   -- dispatched, plaintext
+//                                                   never crosses C↔Lua
+//                                                   boundary on the way out
+//
+// The first three are thin wrappers over `Security::CredStore`. The
+// fourth is the load-bearing one: it pulls the encrypted blob, calls
+// the engine's own `FUN_GLUE_LOGIN_ATTEMPT` (the function that
+// `Script_DefaultServerLogin` tail-calls into), then scrubs the
+// stack buffer. The engine itself zero-fills the password buffer
+// after consuming it (see Offsets::FUN_GLUE_LOGIN_ATTEMPT docs), so
+// the scrub here is belt-and-suspenders for any prefix bytes the
+// engine's strlen-based wipe might miss.
+//
+// Registered on the glue Lua state only — there's no use for these
+// outside the AccountLogin screen, and keeping them off the in-game
+// state means no addon can call `LoginWithSavedAccount` to trigger
+// an unexpected logout-and-login flow.
+
+#include "CredStore.h"
+#include "Game.h"
+#include "Offsets.h"
+
+#include <windows.h>
+
+#include <cstring>
+#include <vector>
+
+namespace Security::Account {
+
+namespace {
+
+const char *ArgString(void *L, int idx) {
+    if (!Game::Lua::IsString(L, idx))
+        return nullptr;
+    return Game::Lua::ToString(L, idx);
+}
+
+// Engine login entry. `__fastcall(ecx = account, edx = mutable
+// password buffer)`. The engine zero-fills the password buffer after
+// SRP consumes it.
+using LoginAttempt_t = void(__fastcall *)(const char *account, char *passwordMutable);
+// `reinterpret_cast` from integer to function-pointer isn't constant
+// in C++17, so the cast lives in the call site instead of a constexpr
+// const.
+inline void LoginAttempt(const char *account, char *passwordMutable) {
+    reinterpret_cast<LoginAttempt_t>(Offsets::FUN_GLUE_LOGIN_ATTEMPT)(
+        account, passwordMutable);
+}
+
+int __fastcall Script_SaveAccount(void *L) {
+    const char *name = ArgString(L, 1);
+    const char *password = ArgString(L, 2);
+    const bool ok =
+        name && *name && password && *password &&
+        Security::CredStore::Save(name, password);
+    Game::Lua::PushBool(L, ok);
+    return 1;
+}
+
+int __fastcall Script_DeleteAccount(void *L) {
+    const char *name = ArgString(L, 1);
+    const bool ok = name && *name && Security::CredStore::Delete(name);
+    Game::Lua::PushBool(L, ok);
+    return 1;
+}
+
+int __fastcall Script_GetSavedAccounts(void *L) {
+    auto accounts = Security::CredStore::List();
+    Game::Lua::SetTop(L, 0);
+    Game::Lua::NewTable(L);
+    int key = 1;
+    for (const auto &acct : accounts) {
+        Game::Lua::PushNumber(L, static_cast<double>(key++));
+        Game::Lua::PushString(L, acct.c_str());
+        Game::Lua::SetTable(L, -3);
+    }
+    return 1;
+}
+
+int __fastcall Script_LoginWithSavedAccount(void *L) {
+    const char *name = ArgString(L, 1);
+    if (!name || !*name) {
+        Game::Lua::PushBool(L, false);
+        return 1;
+    }
+
+    std::vector<char> password;
+    if (!Security::CredStore::Load(name, password) || password.empty()) {
+        Game::Lua::PushBool(L, false);
+        return 1;
+    }
+
+    // CredStore::Load gives us a vector sized to the password length
+    // with a trailing nul one past the end (resize to len after writing
+    // len+1 bytes). The engine login function reads via strlen, so we
+    // need the nul terminator accessible — `data()[size()]` is valid
+    // on std::vector (the spec guarantees a writable element there
+    // since C++11). Engine will zero out the bytes up through strlen
+    // after SRP consumes them.
+    LoginAttempt(name, password.data());
+
+    // Belt-and-suspenders scrub. Engine already zeroed `password.size()`
+    // bytes, but we re-scrub the full vector capacity in case the
+    // engine's wipe assumed an exact strlen match.
+    if (!password.empty()) {
+        SecureZeroMemory(password.data(), password.size());
+    }
+
+    Game::Lua::PushBool(L, true);
+    return 1;
+}
+
+void RegisterGlueFunctions() {
+    Game::Lua::RegisterGlueFunction("SaveAccount", &Script_SaveAccount);
+    Game::Lua::RegisterGlueFunction("DeleteAccount", &Script_DeleteAccount);
+    Game::Lua::RegisterGlueFunction("GetSavedAccounts", &Script_GetSavedAccounts);
+    Game::Lua::RegisterGlueFunction("LoginWithSavedAccount",
+                                    &Script_LoginWithSavedAccount);
+}
+
+const Game::GlueModuleAutoRegister _autoreg{&RegisterGlueFunctions};
+
+} // namespace
+
+} // namespace Security::Account

--- a/src/security/CredStore.cpp
+++ b/src/security/CredStore.cpp
@@ -1,0 +1,219 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Lesser General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#include "CredStore.h"
+
+#include "Offsets.h"
+
+#include <windows.h>
+#include <wincred.h>
+
+namespace Security::CredStore {
+
+namespace {
+
+constexpr const wchar_t kTargetPrefix[] = L"ClassicAPI/WoW/";
+constexpr size_t kTargetPrefixLen =
+    sizeof(kTargetPrefix) / sizeof(wchar_t) - 1;
+
+// Cred Manager target-name max is 32767 wchars; vanilla WoW account
+// names cap at 0x40 bytes (see VAR_GLUE_LOGIN_ATTEMPT prologue). We
+// allow generous bounds for the realm + account, leaving the rest of
+// the target-name budget unused.
+constexpr size_t kMaxRealmWChars = 256;
+constexpr size_t kMaxAccountWChars = 256;
+
+using GetRealmList_t = const char *(__fastcall *)(int forceRefresh);
+
+// Returns the current engine realmList CVar's value, or empty string
+// if unset. This is the realmlist address (e.g.
+// "logon.turtle-wow.org"), not the friendly display name — scoping
+// credentials on the address means two private servers with the same
+// display name still get distinct vault entries.
+std::string CurrentRealm() {
+    const char *r = reinterpret_cast<GetRealmList_t>(
+        Offsets::FUN_CVAR_REALM_LIST)(0);
+    if (!r || !*r) return {};
+    return r;
+}
+
+// Append a UTF-8 string `s` to `out` as wide chars. No-op (and false
+// return) on conversion error or empty input. `max` caps the wchar
+// count we'll append.
+bool AppendWide(std::wstring &out, const char *s, size_t max) {
+    if (!s || !*s) return false;
+    int needed = MultiByteToWideChar(CP_UTF8, 0, s, -1, nullptr, 0);
+    if (needed <= 1) return false;
+    if (static_cast<size_t>(needed) > max) return false;
+    size_t base = out.size();
+    out.resize(base + needed - 1);
+    MultiByteToWideChar(CP_UTF8, 0, s, -1, &out[base], needed);
+    return true;
+}
+
+// Builds the per-account target name:
+//     ClassicAPI/WoW/<realmName>/<accountName>
+//
+// Returns the bare prefix when the realm or account is missing —
+// callers use `result.size() > kTargetPrefixLen` to detect that and
+// abort.
+std::wstring MakeTargetName(const char *accountName) {
+    std::wstring out(kTargetPrefix, kTargetPrefixLen);
+    std::string realm = CurrentRealm();
+    if (realm.empty()) return out;
+    if (!AppendWide(out, realm.c_str(), kMaxRealmWChars)) {
+        out.resize(kTargetPrefixLen);
+        return out;
+    }
+    out.push_back(L'/');
+    if (!AppendWide(out, accountName, kMaxAccountWChars)) {
+        out.resize(kTargetPrefixLen);
+        return out;
+    }
+    return out;
+}
+
+// Builds the enumeration filter for the current realm:
+//     ClassicAPI/WoW/<realmName>/*
+//
+// Returns empty wstring if no realm is set (callers treat that as
+// "no entries to list").
+std::wstring MakeEnumFilter() {
+    std::wstring out(kTargetPrefix, kTargetPrefixLen);
+    std::string realm = CurrentRealm();
+    if (realm.empty()) return {};
+    if (!AppendWide(out, realm.c_str(), kMaxRealmWChars)) return {};
+    out.push_back(L'/');
+    out.push_back(L'*');
+    return out;
+}
+
+// Extracts the account-name suffix from a target-name during enum.
+// Returns empty string if the structural shape doesn't match — the
+// CredEnumerate filter should already restrict to our namespace, but
+// hostile or stale entries from a previous version of this code could
+// in theory land here.
+std::string ExtractAccount(const wchar_t *targetName) {
+    if (!targetName) return {};
+    if (wcsncmp(targetName, kTargetPrefix, kTargetPrefixLen) != 0) {
+        return {};
+    }
+    // After the prefix we expect `<realm>/<account>`. Skip past the
+    // realm by finding the next '/'.
+    const wchar_t *afterPrefix = targetName + kTargetPrefixLen;
+    const wchar_t *sep = wcschr(afterPrefix, L'/');
+    if (!sep || !sep[1]) return {};
+    const wchar_t *account = sep + 1;
+    int needed = WideCharToMultiByte(CP_UTF8, 0, account, -1,
+                                     nullptr, 0, nullptr, nullptr);
+    if (needed <= 1) return {};
+    std::string out(static_cast<size_t>(needed - 1), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, account, -1, &out[0], needed,
+                        nullptr, nullptr);
+    return out;
+}
+
+} // namespace
+
+bool Save(const char *accountName, const char *password) {
+    if (!accountName || !*accountName) return false;
+    if (!password || !*password) return false;
+
+    std::wstring target = MakeTargetName(accountName);
+    if (target.size() == kTargetPrefixLen) return false; // empty account
+
+    size_t pwLen = strlen(password);
+    if (pwLen == 0 || pwLen > CRED_MAX_CREDENTIAL_BLOB_SIZE) return false;
+
+    CREDENTIALW cred{};
+    cred.Type = CRED_TYPE_GENERIC;
+    cred.TargetName = const_cast<LPWSTR>(target.c_str());
+    cred.CredentialBlobSize = static_cast<DWORD>(pwLen);
+    cred.CredentialBlob =
+        reinterpret_cast<LPBYTE>(const_cast<char *>(password));
+    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    // UserName is required by some advapi32 builds to be non-NULL even
+    // for generic credentials; reuse the target so the entry is
+    // visually labeled correctly in `control /name
+    // Microsoft.CredentialManager` even though we don't read it back.
+    cred.UserName = const_cast<LPWSTR>(target.c_str());
+
+    return CredWriteW(&cred, 0) != FALSE;
+}
+
+bool Delete(const char *accountName) {
+    if (!accountName || !*accountName) return false;
+    std::wstring target = MakeTargetName(accountName);
+    if (target.size() == kTargetPrefixLen) return false;
+    return CredDeleteW(target.c_str(), CRED_TYPE_GENERIC, 0) != FALSE;
+}
+
+std::vector<std::string> List() {
+    std::vector<std::string> result;
+
+    // Enumeration filter is scoped to the current realm, so entries
+    // for other private servers are invisible. The wildcard pattern
+    // `ClassicAPI/WoW/<realm>/*` matches every account under it.
+    std::wstring filter = MakeEnumFilter();
+    if (filter.empty()) return result;
+
+    DWORD count = 0;
+    PCREDENTIALW *entries = nullptr;
+    if (!CredEnumerateW(filter.c_str(), 0, &count, &entries)) {
+        // ERROR_NOT_FOUND is the expected "no entries yet" outcome.
+        return result;
+    }
+
+    result.reserve(count);
+    for (DWORD i = 0; i < count; ++i) {
+        if (!entries[i] || !entries[i]->TargetName) continue;
+        std::string account = ExtractAccount(entries[i]->TargetName);
+        if (!account.empty()) result.push_back(std::move(account));
+    }
+    CredFree(entries);
+    return result;
+}
+
+bool Load(const char *accountName, std::vector<char> &outPassword) {
+    outPassword.clear();
+    if (!accountName || !*accountName) return false;
+
+    std::wstring target = MakeTargetName(accountName);
+    if (target.size() == kTargetPrefixLen) return false;
+
+    PCREDENTIALW cred = nullptr;
+    if (!CredReadW(target.c_str(), CRED_TYPE_GENERIC, 0, &cred)) {
+        return false;
+    }
+    if (!cred || !cred->CredentialBlob || cred->CredentialBlobSize == 0) {
+        if (cred) CredFree(cred);
+        return false;
+    }
+
+    const DWORD len = cred->CredentialBlobSize;
+    outPassword.resize(static_cast<size_t>(len) + 1, '\0');
+    memcpy(outPassword.data(), cred->CredentialBlob, len);
+    outPassword[len] = '\0';
+    // size() should reflect the password length, not the trailing nul.
+    outPassword.resize(len);
+
+    // Zero the OS-returned buffer before freeing — CredFree itself
+    // doesn't scrub. Safe even though the blob is a const-ish field,
+    // because we own it until CredFree returns and the API never
+    // reuses the allocation.
+    SecureZeroMemory(cred->CredentialBlob, len);
+    CredFree(cred);
+    return true;
+}
+
+} // namespace Security::CredStore

--- a/src/security/CredStore.cpp
+++ b/src/security/CredStore.cpp
@@ -158,8 +158,25 @@ bool Delete(const char *accountName) {
     return CredDeleteW(target.c_str(), CRED_TYPE_GENERIC, 0) != FALSE;
 }
 
-std::vector<std::string> List() {
-    std::vector<std::string> result;
+namespace {
+
+// FILETIME (100-ns intervals since 1601-01-01) → Unix epoch seconds.
+// Returns 0 for zero/invalid input.
+uint64_t FileTimeToUnix(FILETIME ft) {
+    const uint64_t v = (static_cast<uint64_t>(ft.dwHighDateTime) << 32) |
+                       ft.dwLowDateTime;
+    if (v == 0) return 0;
+    // 11644473600 seconds between 1601-01-01 and 1970-01-01, expressed
+    // in 100-ns ticks.
+    constexpr uint64_t kEpochDiff100ns = 116444736000000000ULL;
+    if (v < kEpochDiff100ns) return 0;
+    return (v - kEpochDiff100ns) / 10000000ULL;
+}
+
+} // namespace
+
+std::vector<Entry> List() {
+    std::vector<Entry> result;
 
     // Enumeration filter is scoped to the current realm, so entries
     // for other private servers are invisible. The wildcard pattern
@@ -178,7 +195,9 @@ std::vector<std::string> List() {
     for (DWORD i = 0; i < count; ++i) {
         if (!entries[i] || !entries[i]->TargetName) continue;
         std::string account = ExtractAccount(entries[i]->TargetName);
-        if (!account.empty()) result.push_back(std::move(account));
+        if (account.empty()) continue;
+        result.push_back({std::move(account),
+                          FileTimeToUnix(entries[i]->LastWritten)});
     }
     CredFree(entries);
     return result;

--- a/src/security/CredStore.h
+++ b/src/security/CredStore.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -48,9 +49,19 @@ bool Save(const char *accountName, const char *password);
 // realm. Returns true if a matching entry existed and was deleted.
 bool Delete(const char *accountName);
 
+// One entry returned by `List()` — the account name plus the
+// Windows-tracked `LastWritten` timestamp converted to Unix epoch
+// seconds. The engine refreshes `LastWritten` on every `CredWriteW`,
+// so `LoginWithSavedAccount` re-saves the credential after use to
+// keep the timestamp current ("last written" == "last used").
+struct Entry {
+    std::string name;
+    uint64_t lastUsedUnix;
+};
+
 // Enumerate every saved account for the current engine realm. Empty
 // list if no realm is set or no entries exist.
-std::vector<std::string> List();
+std::vector<Entry> List();
 
 // Load the password for `accountName` under the current engine realm
 // into `outPassword`. The output is nul-terminated and the vector's

--- a/src/security/CredStore.h
+++ b/src/security/CredStore.h
@@ -1,0 +1,63 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU Lesser General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+// Thin C++ wrapper over the Win32 Credential Manager API (advapi32.dll:
+// CredWriteW / CredReadW / CredEnumerateW / CredDeleteW). Entries are
+// stored under per-user, DPAPI-encrypted blobs that other Windows users
+// on the same machine cannot read; any process running as the current
+// user can decrypt them (DPAPI is per-user, not per-process), so this
+// is "secure at rest", not "secure against same-user attackers".
+//
+// Every operation is scoped by the current engine `realmList` CVar
+// (the realmlist address from `realmlist.wtf` — e.g.
+// "logon.turtle-wow.org", not the friendly display name). The same
+// account name on two different private servers therefore gets two
+// distinct vault entries:
+//     ClassicAPI/WoW/logon.turtle-wow.org/MYACCT
+//     ClassicAPI/WoW/logon.other-server.com/MYACCT
+// Users can inspect/wipe entries via
+// `control /name Microsoft.CredentialManager` → Generic Credentials.
+//
+// When no realmList is set, every operation returns false / empty —
+// there's no meaningful key to scope under.
+
+namespace Security::CredStore {
+
+// Save (or overwrite) the password for `accountName` under the current
+// engine realm. Returns false if no realm is set, the account name is
+// empty, the password is empty, or the OS rejects the write.
+bool Save(const char *accountName, const char *password);
+
+// Delete the saved entry for `accountName` under the current engine
+// realm. Returns true if a matching entry existed and was deleted.
+bool Delete(const char *accountName);
+
+// Enumerate every saved account for the current engine realm. Empty
+// list if no realm is set or no entries exist.
+std::vector<std::string> List();
+
+// Load the password for `accountName` under the current engine realm
+// into `outPassword`. The output is nul-terminated and the vector's
+// `size()` reflects the password length (not including the trailing
+// nul). Returns false if no realm is set or no such entry exists. The
+// caller should `SecureZeroMemory(outPassword.data(), outPassword.size())`
+// after use.
+bool Load(const char *accountName, std::vector<char> &outPassword);
+
+} // namespace Security::CredStore


### PR DESCRIPTION
## Summary

Adds a glue-state-only API for storing account passwords in **Windows Credential Manager** (per-user, DPAPI-encrypted), with login dispatched from C so plaintext never crosses the C↔Lua boundary on the way out.

Four new globals registered on the glue Lua state only (login screen):

- `SaveAccount(name, password)` — encrypt + persist under current `realmList`
- `DeleteAccount(name)` — remove an entry
- `GetSavedAccounts()` — `{ name, lastUsed }[]` for the current realmlist only
- `LoginWithSavedAccount(name)` — decrypt internally, hand to engine's login function, refresh `lastUsed` timestamp

Vault entries are scoped on the realmlist CVar (e.g. `logon.turtle-wow.org`) rather than the friendly display name, so two private servers sharing a `realmName` don't share credentials.

Threat model (from `CLAUDE.md`): defeats casual WTF inspection, cloud-sync of WTF, other Windows users on the same machine. Does **not** defeat code running as the current user — but the plaintext-decrypt path is C-only, so hostile addons can trigger a login but can't extract the password.

New dependency: `advapi32` (Windows SDK, no install). Wired into `CMakeLists.txt`.

## Test plan

- [x] Build `ClassicAPI.dll` in Release/Win32 and drop into the loader's DLL dir
- [x] On login screen: `/run SaveAccount("MYACCT","mypass")` — verify success
- [x] `/run for _,e in ipairs(GetSavedAccounts()) do print(e.name, e.lastUsed) end` — entry visible
- [x] `/run LoginWithSavedAccount("MYACCT")` — engine attempts login, `lastUsed` updates
- [x] Switch `realmlist.wtf` to a different server — `GetSavedAccounts()` returns empty
- [x] `/run DeleteAccount("MYACCT")` — entry removed, also gone from `control /name Microsoft.CredentialManager`
- [x] Confirm the four globals are nil in-world (registered glue-only)