### PR TITLE
UNIT_SPELLCAST_* event family + GUID unit tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ when launching with `-console`), not as Lua functions. See the
 | `QUEST_DATA_LOAD_RESULT` | `questID, success` |
 | `QUEST_REMOVED` | `questID` |
 | `QUEST_TURNED_IN` | `questID, xpReward, moneyReward` |
+| `UNIT_SPELLCAST_SENT` | `"player", target, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_START` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_STOP` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_DELAYED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_SUCCEEDED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_INTERRUPTED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_FAILED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_CHANNEL_START` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_CHANNEL_UPDATE` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_CHANNEL_STOP` | `"player", castGUID, spellID, spellName, rank` |
 | `UPDATE_INVENTORY_DURABILITY` | *(none)* |
 | `UPDATE_SHAPESHIFT_FORM` | *(none)* |
 | `VOICE_CHAT_TTS_PLAYBACK_STARTED` | `numConsumers, utteranceID, durationMS, destination` |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ when launching with `-console`), not as Lua functions. See the
 | `UNIT_SPELLCAST_CHANNEL_START` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_UPDATE` | `"player", castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_STOP` | `unit, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_RETICLE_TARGET` | `"player", "", spellID, spellName, rank` |
+| `UNIT_SPELLCAST_RETICLE_CLEAR` | `"player", "", spellID, spellName, rank` |
 | `UPDATE_INVENTORY_DURABILITY` | *(none)* |
 | `UPDATE_SHAPESHIFT_FORM` | *(none)* |
 | `VOICE_CHAT_TTS_PLAYBACK_STARTED` | `numConsumers, utteranceID, durationMS, destination` |

--- a/README.md
+++ b/README.md
@@ -156,15 +156,15 @@ when launching with `-console`), not as Lua functions. See the
 | `QUEST_REMOVED` | `questID` |
 | `QUEST_TURNED_IN` | `questID, xpReward, moneyReward` |
 | `UNIT_SPELLCAST_SENT` | `"player", target, castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_START` | `"player", castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_STOP` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_START` | `unit, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_STOP` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_DELAYED` | `"player", castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_SUCCEEDED` | `"player", castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_INTERRUPTED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_SUCCEEDED` | `unit, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_INTERRUPTED` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_FAILED` | `"player", castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_CHANNEL_START` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_CHANNEL_START` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_UPDATE` | `"player", castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_CHANNEL_STOP` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_CHANNEL_STOP` | `unit, castGUID, spellID, spellName, rank` |
 | `UPDATE_INVENTORY_DURABILITY` | *(none)* |
 | `UPDATE_SHAPESHIFT_FORM` | *(none)* |
 | `VOICE_CHAT_TTS_PLAYBACK_STARTED` | `numConsumers, utteranceID, durationMS, destination` |

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ when launching with `-console`), not as Lua functions. See the
 | `UNIT_SPELLCAST_SUCCEEDED` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_INTERRUPTED` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_FAILED` | `"player", castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_FAILED_QUIET` | `"player", castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_START` | `unit, castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_UPDATE` | `"player", castGUID, spellID, spellName, rank` |
 | `UNIT_SPELLCAST_CHANNEL_STOP` | `unit, castGUID, spellID, spellName, rank` |

--- a/docs/API.md
+++ b/docs/API.md
@@ -10876,31 +10876,55 @@ otherwise it falls back to `name`/`displayName`/`textureID`/`spellID` with
 **`nil` times**. The player path is unchanged (full timing). Same
 placeholder fields as `C_Spell.UnitCastingInfo`.
 
-### `UNIT_SPELLCAST_*` events (player)
+### `UNIT_SPELLCAST_*` events
 
-Backport of the TBC+ cast/channel events to 1.12 for the **local player**.
-Ported cast-bar / rotation addons (anything written against the modern
-signature) register these instead of vanilla's arg-less `SPELLCAST_*`
-events and read `unit, castGUID, spellID` directly. Ten events are
-provided:
+Backport of the TBC+ cast/channel events to 1.12, for the **local player and
+other units**. Ported cast-bar / rotation addons (anything written against
+the modern signature) register these instead of vanilla's arg-less
+`SPELLCAST_*` events and read `unit, castGUID, spellID` directly. Ten events
+are provided; six also fire for non-player units:
 
-| Event | Fires when | Args |
-|-------|-----------|------|
-| `UNIT_SPELLCAST_SENT` | `CMSG_CAST_SPELL` leaves the client (earliest point) | `unit, target, castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_START` | a cast-time spell begins | `unit, castGUID, spellID, spellName, rank` |
-| `UNIT_SPELLCAST_STOP` | a cast-time spell ends (any reason) | same |
-| `UNIT_SPELLCAST_DELAYED` | pushback extends the cast | same |
-| `UNIT_SPELLCAST_SUCCEEDED` | the spell goes off (`SMSG_SPELL_GO`) — incl. instants | same |
-| `UNIT_SPELLCAST_INTERRUPTED` | a started cast is interrupted (kick, movement, LoS) | same |
-| `UNIT_SPELLCAST_FAILED` | a cast is rejected before it starts (range, mana, cooldown) | same |
-| `UNIT_SPELLCAST_CHANNEL_START` | a channel begins | same |
-| `UNIT_SPELLCAST_CHANNEL_UPDATE` | pushback shortens a channel | same |
-| `UNIT_SPELLCAST_CHANNEL_STOP` | a channel ends | same |
+| Event | Fires when | Units | Args |
+|-------|-----------|-------|------|
+| `UNIT_SPELLCAST_SENT` | `CMSG_CAST_SPELL` leaves the client (earliest point) | player | `unit, target, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_START` | a cast-time spell begins | all | `unit, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_STOP` | a cast-time spell ends (any reason) | all | same |
+| `UNIT_SPELLCAST_DELAYED` | pushback extends the cast | player | same |
+| `UNIT_SPELLCAST_SUCCEEDED` | the spell goes off (`SMSG_SPELL_GO`) — incl. instants | all | same |
+| `UNIT_SPELLCAST_INTERRUPTED` | a started **cast** is interrupted (kick, movement, LoS) — never for channels | all | same |
+| `UNIT_SPELLCAST_FAILED` | a cast is rejected before it starts (range, mana, cooldown) | player | same |
+| `UNIT_SPELLCAST_CHANNEL_START` | a channel begins | all | same |
+| `UNIT_SPELLCAST_CHANNEL_UPDATE` | pushback shortens a channel | player | same |
+| `UNIT_SPELLCAST_CHANNEL_STOP` | a channel ends | all | same |
 
-`unit` (arg1) is always `"player"` — this is the player-only phase; other
-units aren't fanned out yet. `spellName` / `rank` are ClassicAPI tail
-extensions (modern stops at `spellID`); addons reading only the first three
-positional args are unaffected.
+`unit` (arg1) is the token of the casting unit — `"player"` for your own
+casts, or a unit token (`"target"`, `"focus"`, `"party3"`, `"nameplate2"`,
+`"pet"`, `"mouseover"`, …) for another unit. `spellName` / `rank` are
+ClassicAPI tail extensions (modern stops at `spellID`); addons reading only
+the first three positional args are unaffected.
+
+**Per-token fan-out.** A caster GUID can map to several tokens at once (your
+`target` is also `party2` and `nameplate1`). Like retail, the event fires
+**once per token** currently pointing at the caster, so a `target`-frame
+cast bar, a `party2` frame, and a nameplate cast bar each get their own
+event with the same castGUID. Tokens are resolved fresh at fire time (they
+shift frame-to-frame). If you run **SuperWoW**, its raw-GUID token (`"0x…"`)
+is deliberately filtered out — only standard tokens are fanned out.
+
+**Non-player limits.** Only the six events above fire for other units, and
+they're **best-effort** — driven purely by the packets an observer receives:
+- `SENT` never fires (only your own outgoing casts are visible).
+- `DELAYED` / `CHANNEL_UPDATE` never fire (pushback is sent only to the
+  caster, so another unit's bar can't stretch/shrink from damage).
+- `FAILED` never fires (a pre-cast requirement failure is client-local).
+- A remote cast/channel only has timing from the moment its
+  `SMSG_SPELL_START` was observed; casters who were already casting when
+  they came into range have no start time.
+
+**Channels never fire `INTERRUPTED`.** Retail emits only `CHANNEL_STOP` when a
+channel ends, whether it completed or was cut short (verified against retail),
+so ClassicAPI matches that for both the player and other units. `INTERRUPTED`
+is a cast-only event.
 
 **castGUID.** A synthesized string in the modern shape
 `Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`. Vanilla
@@ -10908,8 +10932,15 @@ can't know server / instance / zone, so those three fields are `0`; the
 load-bearing parts are the `spellID` (field 6, which addons `strsplit("-")`
 out) and a unique-per-cast `castUID` (field 7). **Every event of one cast
 carries the same castGUID**, so `SENT` → `START`/`CHANNEL_START` →
-`SUCCEEDED` → `STOP`/`CHANNEL_STOP` all pair up — a chained same-spell
-recast gets its own castUID.
+`SUCCEEDED` → `STOP`/`CHANNEL_STOP` all pair up — including across the caster
+and observers (they converge on the same value), and a chained same-spell
+recast gets its own castUID. The `type` and `castUID` follow Wowhead's
+spell-cast-GUID spec:
+- **Type 3** (real casts — the common case): `castUID` is time-based — the
+  low 23 bits are the cast's UNIX-epoch second, the higher bits a per-second
+  counter.
+- **Type 2** (`UNIT_SPELLCAST_FAILED` — a local-only cast that never reached
+  the server): `castUID` is a plain locally-incrementing integer.
 
 **Ordering** matches modern:
 
@@ -10925,8 +10956,8 @@ kick, moving to cancel, breaking LoS mid-cast) fires `INTERRUPTED`. Holding
 the cast key while running fires `INTERRUPTED` repeatedly (once per retry),
 each reusing the interrupted cast's castGUID — matching retail.
 
-**Channel pushback.** Taking damage while channeling shortens the channel in
-vanilla; `CHANNEL_UPDATE` fires on each hit and
+**Channel pushback (player).** Taking damage while channeling shortens the
+channel in vanilla; `CHANNEL_UPDATE` fires on each hit and
 [`C_Spell.UnitChannelInfo`](#c_spellunitchannelinfounit--c_spellchannelinfo)'s
 `endTimeMs` re-anchors to the server's new remaining time, so cast bars
 shrink correctly. (The event carries no time — like retail it's a "re-read
@@ -10934,7 +10965,7 @@ now" trigger; timing is read back from `UnitChannelInfo`.)
 
 Every fire is gated on whether any frame is registered for that event, so
 the whole system costs one pointer-compare per state transition when no
-addon uses it (no arg synthesis, no DBC lookups).
+addon uses it (no arg synthesis, no DBC lookups, no per-token fan-out).
 
 ```lua
 local f = CreateFrame("Frame")
@@ -10944,15 +10975,15 @@ for _, e in ipairs({
 }) do f:RegisterEvent(e) end
 f:SetScript("OnEvent", function()
     -- vanilla passes event/arg1/... as globals, not function params
-    if arg1 == "player" then print(event, arg3) end  -- arg3 = spellID
+    if arg1 == "target" then print(event, arg3) end  -- arg3 = spellID
 end)
 ```
 
-> **Player-only, and additive to the vanilla `SPELLCAST_*` events.** The
-> engine's own arg-less `SPELLCAST_START` / `SPELLCAST_CHANNEL_UPDATE` / …
-> still fire as before; these `UNIT_`-prefixed events are the modern layer
-> on top. Other units, `UNIT_SPELLCAST_FAILED_QUIET`, and the empowered-cast
-> events are not implemented.
+> **Additive to the vanilla `SPELLCAST_*` events.** The engine's own arg-less
+> `SPELLCAST_START` / `SPELLCAST_CHANNEL_UPDATE` / … still fire as before;
+> these `UNIT_`-prefixed events are the modern layer on top.
+> `UNIT_SPELLCAST_FAILED_QUIET` and the empowered-cast events are not
+> implemented.
 
 ### `C_Spell.GetSpellLevelInfo(spellID)`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10842,9 +10842,12 @@ so progress is `(GetTime()*1000 - startTimeMs) / (endTimeMs - startTimeMs)`.
 > the **effective** cast time (the engine's own cast-time helper: base +
 > level scaling + cast-time talents like Improved Frostbolt + the
 > haste/cast-speed multiplier), so it matches the in-game cast bar — e.g.
-> a Mage's talented Frostbolt reads 2.5s, not the 3.0s base. Fields
-> vanilla can't fill are structurally-correct placeholders:
-> `castID`/`castBarID` = `nil`, `notInterruptible` = `false`,
+> a Mage's talented Frostbolt reads 2.5s, not the 3.0s base. `castID` is
+> the cast's **castGUID** — the exact string the
+> [`UNIT_SPELLCAST_*`](#unit_spellcast_-events) events carry for this cast,
+> so you can correlate the polled info with the events (works for the player
+> and other units). Fields vanilla can't fill are structurally-correct
+> placeholders: `castBarID` = `nil`, `notInterruptible` = `false`,
 > `delayTimeMs` = `0`.
 
 ### `C_Spell.UnitChannelInfo(unit)` / `C_Spell.ChannelInfo()`
@@ -10934,8 +10937,8 @@ out) and a unique-per-cast `castUID` (field 7). **Every event of one cast
 carries the same castGUID**, so `SENT` → `START`/`CHANNEL_START` →
 `SUCCEEDED` → `STOP`/`CHANNEL_STOP` all pair up — including across the caster
 and observers (they converge on the same value), and a chained same-spell
-recast gets its own castUID. The `type` and `castUID` follow Wowhead's
-spell-cast-GUID spec:
+recast gets its own castUID. The `type` and `castUID` follow the
+[spell-cast-GUID spec](https://warcraft.wiki.gg/wiki/GUID#Cast):
 - **Type 3** (real casts — the common case): `castUID` is time-based — the
   low 23 bits are the cast's UNIX-epoch second, the higher bits a per-second
   counter.

--- a/docs/API.md
+++ b/docs/API.md
@@ -10884,7 +10884,7 @@ placeholder fields as `C_Spell.UnitCastingInfo`.
 Backport of the TBC+ cast/channel events to 1.12, for the **local player and
 other units**. Ported cast-bar / rotation addons (anything written against
 the modern signature) register these instead of vanilla's arg-less
-`SPELLCAST_*` events and read `unit, castGUID, spellID` directly. Twelve
+`SPELLCAST_*` events and read `unit, castGUID, spellID` directly. Thirteen
 events are provided; six also fire for non-player units:
 
 | Event | Fires when | Units | Args |
@@ -10895,7 +10895,8 @@ events are provided; six also fire for non-player units:
 | `UNIT_SPELLCAST_DELAYED` | pushback extends the cast | player | same |
 | `UNIT_SPELLCAST_SUCCEEDED` | the spell goes off (`SMSG_SPELL_GO`) — incl. instants | all | same |
 | `UNIT_SPELLCAST_INTERRUPTED` | a started **cast** is interrupted (kick, movement, LoS) — never for channels | all | same |
-| `UNIT_SPELLCAST_FAILED` | a cast is rejected before it starts (range, mana, cooldown) | player | same |
+| `UNIT_SPELLCAST_FAILED` | a cast is rejected before it starts (range, mana, cooldown) with an error shown | player | same |
+| `UNIT_SPELLCAST_FAILED_QUIET` | a cast fails with **no** error shown (spammy retry, reticle cancel, …) | player | same |
 | `UNIT_SPELLCAST_CHANNEL_START` | a channel begins | all | same |
 | `UNIT_SPELLCAST_CHANNEL_UPDATE` | pushback shortens a channel | player | same |
 | `UNIT_SPELLCAST_CHANNEL_STOP` | a channel ends | all | same |
@@ -10962,10 +10963,15 @@ recast gets its own castUID. The `type` and `castUID` follow the
   before SUCCEEDED, as on retail).
 - Instant: `SENT → SUCCEEDED`.
 
-**INTERRUPTED vs FAILED** follow modern's split: a spell that never started
-(out of range, not enough mana, on cooldown, LoS to a target) fires
-`FAILED`; a spell that was *already casting* and gets stopped (an enemy
-kick, moving to cancel, breaking LoS mid-cast) fires `INTERRUPTED`. Holding
+**INTERRUPTED vs FAILED vs FAILED_QUIET** follow modern's split: a spell that
+never started (out of range, not enough mana, on cooldown, LoS to a target)
+fires `FAILED`, except for a fixed whitelist of "quiet" `SpellCastResult`
+codes that fire `FAILED_QUIET` instead — `SPELL_IN_PROGRESS` (casting while
+already casting / a spell-queue rejection), `DONT_REPORT` (fake fails, a
+cancelled ground reticle), and `CHARMED`. That whitelist mirrors the 3.3.5
+client's own unit-spellcast dispatch, mapped to vanilla's `SpellCastResult`
+enum. A spell that was *already casting* and gets stopped (an enemy kick,
+moving to cancel, breaking LoS mid-cast) fires `INTERRUPTED`. Holding
 the cast key while running fires `INTERRUPTED` repeatedly (once per retry),
 each reusing the interrupted cast's castGUID — matching retail.
 
@@ -10994,9 +11000,9 @@ end)
 
 > **Additive to the vanilla `SPELLCAST_*` events.** The engine's own arg-less
 > `SPELLCAST_START` / `SPELLCAST_CHANNEL_UPDATE` / … still fire as before;
-> these `UNIT_`-prefixed events are the modern layer on top.
-> `UNIT_SPELLCAST_FAILED_QUIET` and the empowered-cast events are not
-> implemented.
+> these `UNIT_`-prefixed events are the modern layer on top. The empowered-cast
+> events (`UNIT_SPELLCAST_EMPOWER_*`, a Dragonflight addition) are not
+> implemented — vanilla has no empowered casts.
 
 ### `C_Spell.GetSpellLevelInfo(spellID)`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10884,8 +10884,8 @@ placeholder fields as `C_Spell.UnitCastingInfo`.
 Backport of the TBC+ cast/channel events to 1.12, for the **local player and
 other units**. Ported cast-bar / rotation addons (anything written against
 the modern signature) register these instead of vanilla's arg-less
-`SPELLCAST_*` events and read `unit, castGUID, spellID` directly. Ten events
-are provided; six also fire for non-player units:
+`SPELLCAST_*` events and read `unit, castGUID, spellID` directly. Twelve
+events are provided; six also fire for non-player units:
 
 | Event | Fires when | Units | Args |
 |-------|-----------|-------|------|
@@ -10899,6 +10899,8 @@ are provided; six also fire for non-player units:
 | `UNIT_SPELLCAST_CHANNEL_START` | a channel begins | all | same |
 | `UNIT_SPELLCAST_CHANNEL_UPDATE` | pushback shortens a channel | player | same |
 | `UNIT_SPELLCAST_CHANNEL_STOP` | a channel ends | all | same |
+| `UNIT_SPELLCAST_RETICLE_TARGET` | a ground-target reticle appears (AoE placement — Blizzard, Flare, …) | player | `unit, "", spellID, spellName, rank` |
+| `UNIT_SPELLCAST_RETICLE_CLEAR` | the reticle is placed or cancelled | player | `unit, "", spellID, spellName, rank` |
 
 `unit` (arg1) is the token of the casting unit — `"player"` for your own
 casts, or a unit token (`"target"`, `"focus"`, `"party3"`, `"nameplate2"`,
@@ -10928,6 +10930,14 @@ they're **best-effort** — driven purely by the packets an observer receives:
 channel ends, whether it completed or was cut short (verified against retail),
 so ClassicAPI matches that for both the player and other units. `INTERRUPTED`
 is a cast-only event.
+
+**Reticle events** fire for ground-targeted (AoE) spells only, always for the
+player: `RETICLE_TARGET` when the placement reticle comes up, `RETICLE_CLEAR`
+when it's placed or cancelled. There's no cast yet, so the castGUID slot
+(arg2) is empty — retail pushes `nil` there, but the engine's event
+dispatcher can't emit a `nil` mid-argument-list, so ClassicAPI pushes `""`
+instead. `unit` (arg1) and `spellID` (arg3) are exact; arg2 is the only
+difference and is inconsequential for a reticle.
 
 **castGUID.** A synthesized string in the modern shape
 `Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`. Vanilla

--- a/docs/API.md
+++ b/docs/API.md
@@ -8710,6 +8710,31 @@ the unmodified resolver. The ordered list is maintained alongside
 the existing `NAME_PLATE_UNIT_ADDED` / `_REMOVED` diff in the
 per-tick nameplate walker.
 
+### Unit tokens (GUID literals)
+
+A raw 64-bit GUID literal — `"0x"` followed by up to 16 hex digits
+(e.g. `"0xF130000000000A5"`) — works as a unit token against the same
+`UnitX` surface, so a GUID can be passed anywhere a token is expected:
+
+```lua
+local guid = UnitGUID("target")        -- e.g. "0xF13000..."
+print(UnitName(guid), UnitHealth(guid), UnitClass(guid))
+```
+
+Hex parsing is case-insensitive; the parsed GUID is handed to the engine's
+own object-manager lookup (the identical path `"player"` takes), so a GUID
+for a unit that isn't currently loaded (out of range, not synced) resolves
+to `nil` exactly like any absent unit — no error. Suffix chains compose:
+`"0x…target"` walks to the referenced unit's target.
+
+This is the **input** direction only — to obtain a token's GUID use
+[`UnitGUID`](#unitguidunit).
+
+**Compatible with SuperWoW.** SuperWoW provides the same GUID-input support,
+so when it's loaded we detect it and defer to its resolver (no double
+handling); when it isn't, this fills the gap. Either way GUID-token input
+behaves identically, so addons needn't care whether SuperWoW is present.
+
 ## NameCache
 
 GUID-keyed cache of player names and classes. The engine itself
@@ -12460,6 +12485,10 @@ local guid = UnitGUID("player")  -- "0x0000000000000777" (low IDs are local-real
 local guid = UnitGUID("target")  -- "0xF13000059A002553" (the F130... prefix tags creatures)
 local guid = UnitGUID("party1")  -- works even if party1 is on a different continent
 ```
+
+The returned string is itself accepted as a unit token — `UnitName(guid)`,
+`UnitHealth(guid)`, etc. all work — so a GUID round-trips as a stable
+handle. See [Unit tokens (GUID literals)](#unit-tokens-guid-literals).
 
 **Works for OOR party / raid members.** Earlier versions of this
 function returned nil for `"partyN"` / `"raidN"` when the member's

--- a/docs/API.md
+++ b/docs/API.md
@@ -442,6 +442,7 @@ build instructions.
   - [`C_Spell.CancelSpellByID(spellID)` / `CancelSpellByName(name)`](#c_spellcancelspellbyidspellid--cancelspellbynamename)
   - [`C_Spell.UnitCastingInfo(unit)` / `C_Spell.CastingInfo()`](#c_spellunitcastinginfounit--c_spellcastinginfo)
   - [`C_Spell.UnitChannelInfo(unit)` / `C_Spell.ChannelInfo()`](#c_spellunitchannelinfounit--c_spellchannelinfo)
+  - [`UNIT_SPELLCAST_*` events (player)](#unit_spellcast_-events-player)
   - [`C_Spell.GetSpellLevelInfo(spellID)`](#c_spellgetspelllevelinfospellid)
   - [`GetSpellRequiredTargetLevel(spellID)`](#getspellrequiredtargetlevelspellid)
 
@@ -10874,6 +10875,84 @@ so a stale cache entry never applies to a different/ended channel);
 otherwise it falls back to `name`/`displayName`/`textureID`/`spellID` with
 **`nil` times**. The player path is unchanged (full timing). Same
 placeholder fields as `C_Spell.UnitCastingInfo`.
+
+### `UNIT_SPELLCAST_*` events (player)
+
+Backport of the TBC+ cast/channel events to 1.12 for the **local player**.
+Ported cast-bar / rotation addons (anything written against the modern
+signature) register these instead of vanilla's arg-less `SPELLCAST_*`
+events and read `unit, castGUID, spellID` directly. Ten events are
+provided:
+
+| Event | Fires when | Args |
+|-------|-----------|------|
+| `UNIT_SPELLCAST_SENT` | `CMSG_CAST_SPELL` leaves the client (earliest point) | `unit, target, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_START` | a cast-time spell begins | `unit, castGUID, spellID, spellName, rank` |
+| `UNIT_SPELLCAST_STOP` | a cast-time spell ends (any reason) | same |
+| `UNIT_SPELLCAST_DELAYED` | pushback extends the cast | same |
+| `UNIT_SPELLCAST_SUCCEEDED` | the spell goes off (`SMSG_SPELL_GO`) — incl. instants | same |
+| `UNIT_SPELLCAST_INTERRUPTED` | a started cast is interrupted (kick, movement, LoS) | same |
+| `UNIT_SPELLCAST_FAILED` | a cast is rejected before it starts (range, mana, cooldown) | same |
+| `UNIT_SPELLCAST_CHANNEL_START` | a channel begins | same |
+| `UNIT_SPELLCAST_CHANNEL_UPDATE` | pushback shortens a channel | same |
+| `UNIT_SPELLCAST_CHANNEL_STOP` | a channel ends | same |
+
+`unit` (arg1) is always `"player"` — this is the player-only phase; other
+units aren't fanned out yet. `spellName` / `rank` are ClassicAPI tail
+extensions (modern stops at `spellID`); addons reading only the first three
+positional args are unaffected.
+
+**castGUID.** A synthesized string in the modern shape
+`Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`. Vanilla
+can't know server / instance / zone, so those three fields are `0`; the
+load-bearing parts are the `spellID` (field 6, which addons `strsplit("-")`
+out) and a unique-per-cast `castUID` (field 7). **Every event of one cast
+carries the same castGUID**, so `SENT` → `START`/`CHANNEL_START` →
+`SUCCEEDED` → `STOP`/`CHANNEL_STOP` all pair up — a chained same-spell
+recast gets its own castUID.
+
+**Ordering** matches modern:
+
+- Cast-time spell: `SENT → START → SUCCEEDED → STOP`.
+- Channel: `SENT → CHANNEL_START → SUCCEEDED → CHANNEL_STOP` (CHANNEL_START
+  before SUCCEEDED, as on retail).
+- Instant: `SENT → SUCCEEDED`.
+
+**INTERRUPTED vs FAILED** follow modern's split: a spell that never started
+(out of range, not enough mana, on cooldown, LoS to a target) fires
+`FAILED`; a spell that was *already casting* and gets stopped (an enemy
+kick, moving to cancel, breaking LoS mid-cast) fires `INTERRUPTED`. Holding
+the cast key while running fires `INTERRUPTED` repeatedly (once per retry),
+each reusing the interrupted cast's castGUID — matching retail.
+
+**Channel pushback.** Taking damage while channeling shortens the channel in
+vanilla; `CHANNEL_UPDATE` fires on each hit and
+[`C_Spell.UnitChannelInfo`](#c_spellunitchannelinfounit--c_spellchannelinfo)'s
+`endTimeMs` re-anchors to the server's new remaining time, so cast bars
+shrink correctly. (The event carries no time — like retail it's a "re-read
+now" trigger; timing is read back from `UnitChannelInfo`.)
+
+Every fire is gated on whether any frame is registered for that event, so
+the whole system costs one pointer-compare per state transition when no
+addon uses it (no arg synthesis, no DBC lookups).
+
+```lua
+local f = CreateFrame("Frame")
+for _, e in ipairs({
+    "UNIT_SPELLCAST_START", "UNIT_SPELLCAST_STOP",
+    "UNIT_SPELLCAST_SUCCEEDED", "UNIT_SPELLCAST_CHANNEL_START",
+}) do f:RegisterEvent(e) end
+f:SetScript("OnEvent", function()
+    -- vanilla passes event/arg1/... as globals, not function params
+    if arg1 == "player" then print(event, arg3) end  -- arg3 = spellID
+end)
+```
+
+> **Player-only, and additive to the vanilla `SPELLCAST_*` events.** The
+> engine's own arg-less `SPELLCAST_START` / `SPELLCAST_CHANNEL_UPDATE` / …
+> still fire as before; these `UNIT_`-prefixed events are the modern layer
+> on top. Other units, `UNIT_SPELLCAST_FAILED_QUIET`, and the empowered-cast
+> events are not implemented.
 
 ### `C_Spell.GetSpellLevelInfo(spellID)`
 

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -554,6 +554,24 @@ enum Offsets {
     // input it's the right primitive.
     FUN_TOKEN_TO_GUID = 0x00515970,
 
+    // `__fastcall(const uint64_t *guid /*ecx*/, int *outCount /*edx*/) ->
+    // char** tokenArray` — the engine's GUID → unit-token REVERSE map. Fills
+    // a reused static buffer array (the returned pointer) with the name
+    // string of every ENGINE-NATIVE token currently pointing at `guid` and
+    // writes the count to `*outCount`. Checks, in order: player, pet, target,
+    // party1..4, partypet1..4, raid1..40, raidpet1..40, npc, mouseover — the
+    // same slots the per-token unit-event broadcast `FUN_00515e50` fans out
+    // to (that function is just this map + a fire-per-token loop). Does NOT
+    // know ClassicAPI's synthetic `focus` / `nameplateN` tokens (the engine
+    // has no concept of them) — callers add those separately. Non-throwing:
+    // returns count 0 pre-world (resolves the active player internally and
+    // bails if absent). The returned array is a shared static reused on the
+    // next call, so snapshot the strings before doing anything that could
+    // re-enter. nampower names this `GetNamesFromGUID` (left as an unfilled
+    // TODO in its offsets.hpp). Used by `Unit::Identity::TokensForGUID` for
+    // the phase-2 `UNIT_SPELLCAST_*` remote-unit fan-out.
+    FUN_UNIT_TOKENS_FROM_GUID = 0x00515C50,
+
     // Mouseover-unit GUID globals — the `"mouseover"` token resolves to
     // these (see the token-dispatch list above). Written ONLY by
     // `FUN_SET_MOUSEOVER_UNIT`; zero when nothing is moused over. Used by

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -3565,6 +3565,23 @@ enum Offsets {
     // `FUN_006E3D10`. Non-zero means "the cast bar is showing this
     // spell"; cleared to 0 when the cast finishes or is cancelled.
     VAR_CURRENT_CAST_SPELL = 0x00CECA88,
+
+    // Ground/reticle-targeting flags — non-zero while a spell is awaiting a
+    // target click (the AoE reticle / target cursor). `SpellIsTargeting()`
+    // (`0x006E6CD0`) returns true iff this != 0 (via its predicate
+    // `FUN_006E48A0`, `return DAT_00CECAC0 != 0`); `Spell_C_TargetSpell`
+    // (`0x006E5250`) sets the flag bits from the spell's target type, and the
+    // clear helper `FUN_006E4900` (from `SpellStopTargeting`) / a ground
+    // placement zeroes it. Polled by `Spell::CastEvents::PollReticle` to fire
+    // UNIT_SPELLCAST_RETICLE_TARGET / _CLEAR.
+    VAR_SPELL_TARGETING_FLAGS = 0x00CECAC0,
+    // The pending cast spellID — written by `Spell_C_CastSpell` (`0x006E4B60`)
+    // to the spell being cast, and used elsewhere as a `Spell.dbc` index (e.g.
+    // `CancelSpell`'s `records[this]`). While `VAR_SPELL_TARGETING_FLAGS` is
+    // set it's the spell whose reticle is up, so the RETICLE events read the
+    // spellID from here.
+    VAR_PENDING_CAST_SPELL = 0x00CEAC58,
+
     // The cast-start state writer — `__fastcall(int spellID, int
     // targetState)`. Sets `VAR_CURRENT_CAST_SPELL` (pushing any current
     // spell into `VAR_QUEUED_CAST_SPELL`; `spellID == 0` restores the queued

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -1216,6 +1216,20 @@ enum Offsets {
     // collision, per-channel-start frequency).
     FUN_SPELL_CHANNEL_START = 0x006E7550,
 
+    // `MSG_CHANNEL_UPDATE` handler (`FUN_006e75f0`) — same `int __stdcall(
+    // uint32_t *opCode, CDataStore *packet)` shape. Body: a single u32 =
+    // the channel's new REMAINING time (ms). Sent to the caster on damage
+    // pushback (which shortens a vanilla channel) and once more at the
+    // channel's end (remaining == 0). Verified at 0x006e75f0: reads the u32,
+    // then fires vanilla's `SPELLCAST_CHANNEL_UPDATE(remaining)` (event
+    // 0x157) on pushback or `SPELLCAST_CHANNEL_STOP` (0x158) at end — but
+    // stores the new end NOWHERE, so `Spell::Cast`'s g_channel.endMs
+    // (computed once at start) never reflects pushback. Co-hooked to
+    // re-anchor endMs (and fire UNIT_SPELLCAST_CHANNEL_UPDATE). nampower
+    // hooks it too (SpellChannelUpdateHandlerHook — accepted co-hook, per-
+    // pushback frequency, same as the START sibling).
+    FUN_SPELL_CHANNEL_UPDATE = 0x006E75F0,
+
     // `SMSG_SPELL_FAILED_OTHER` handler — `int __stdcall(uint32_t *opCode,
     // CDataStore *packet)`, same shape as FUN_SPELL_DELAYED. Body:
     // `casterGuid(u64, plain), spellId(u32)`. In (v)mangos cores this is
@@ -1244,6 +1258,21 @@ enum Offsets {
     // nampower calls this SpellFailedHandler (offsets.hpp) but doesn't
     // hook it.
     FUN_SPELL_FAILURE = 0x006E8D80,
+
+    // `Spell_C_SpellFailed` — the CLIENT-side cast-failure entry, distinct
+    // from the two SMSG_SPELL_FAILURE/_OTHER packet handlers above. Fires
+    // for the local player's own cast rejections (out of range, no mana,
+    // "spell not ready", LoS, interrupted, …). `__fastcall(uint32_t
+    // spellId, uint8_t spellResult /*edx*/, int unk1, int unk2, bool
+    // failedByServer)` — signature per nampower's Spell_C_SpellFailedT.
+    // Backs `UNIT_SPELLCAST_FAILED` (`Spell::CastEvents`). Not hooked
+    // elsewhere in this project (we hook the packet handlers, not this).
+    FUN_SPELL_C_SPELL_FAILED = 0x006E1A00,
+
+    // `Spell_C_SpellFailed` result code for a fake/suppressed failure
+    // (Unleashed Potential and similar) — the engine's SPELL_FAILED_DONT_
+    // REPORT. nampower filters it out of its failure event; so do we.
+    SPELL_FAILED_DONT_REPORT = 23,
 
     // `CGUnit_C::ClearCastingSpell` — `__thiscall void(CGUnit *unit,
     // int spellID, char notify, char cleanup)` (nampower names the offset

--- a/src/aura/ComboDuration.cpp
+++ b/src/aura/ComboDuration.cpp
@@ -21,6 +21,7 @@
 #include "Offsets.h"
 #include "dbc/Lookup.h"
 #include "net/PacketReader.h"
+#include "net/SendObserver.h"
 #include "spell/Mod.h"
 #include "unit/Identity.h"
 
@@ -86,28 +87,17 @@ int ConsumeCapturedCP(uint32_t spellId) {
 // re-entry, but still build and send CMSG_CAST_SPELL through the engine).
 // Snapshot the combo points at the moment the cast request leaves: the
 // server consumes them before SMSG_SPELL_GO arrives, so reading at
-// SpellGo time is too late.
-using NetSend_t = void(__fastcall *)(void *conn, void *edx,
-                                     CDataStore *packet);
-NetSend_t g_origNetSend = nullptr;
-
-void __fastcall NetSend_h(void *conn, void *edx, CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint32_t opcode = Net::Read<uint32_t>(packet);
-        if (opcode == Offsets::OP_CMSG_CAST_SPELL) {
-            const uint32_t spellId = Net::Read<uint32_t>(packet);
-            if (spellId != 0)
-                g_capture = {spellId, CurrentComboPoints(), NowMs()};
-        }
-        packet->m_read = saved;
-    }
-    g_origNetSend(conn, edx, packet);
+// SpellGo time is too late. We watch sends through the shared
+// `Net::SendObserver` rather than owning the funnel hook ourselves.
+void OnSend(uint32_t opcode, Net::CDataStore *packet) {
+    if (opcode != Offsets::OP_CMSG_CAST_SPELL)
+        return;
+    const uint32_t spellId = Net::Read<uint32_t>(packet);
+    if (spellId != 0)
+        g_capture = {spellId, CurrentComboPoints(), NowMs()};
 }
 
-const Game::HookAutoRegister _sendHook{
-    Offsets::FUN_NET_SEND, reinterpret_cast<void *>(&NetSend_h),
-    reinterpret_cast<void **>(&g_origNetSend)};
+const Net::SendObserver::AutoSubscribe _sendSub{&OnSend};
 
 // ---- Duration data (SpellDuration.dbc + Lua overrides) --------------------
 

--- a/src/aura/Source.cpp
+++ b/src/aura/Source.cpp
@@ -589,6 +589,8 @@ void __fastcall SpellGo_h(uint64_t *itemGUID, uint64_t *casterGUID,
     if (caster == Unit::Identity::PlayerGuid()) {
         Totem::Tracker::OnPlayerSpellGo(spellId);
         Spell::CastEvents::OnPlayerSucceeded(static_cast<int>(spellId));
+    } else {
+        Spell::CastEvents::OnRemoteSucceeded(caster, static_cast<int>(spellId));
     }
 
     // Mirror server-side duration edits the client is never told about

--- a/src/aura/Source.cpp
+++ b/src/aura/Source.cpp
@@ -21,6 +21,7 @@
 #include "Offsets.h"
 #include "net/PacketReader.h"
 #include "player/StatSignal.h"
+#include "spell/CastEvents.h"
 #include "spell/Lookup.h"
 #include "tick/WorldTick.h"
 #include "totem/Tracker.h"
@@ -581,10 +582,14 @@ void __fastcall SpellGo_h(uint64_t *itemGUID, uint64_t *casterGUID,
     if (caster == 0 || spellId == 0)
         return;
 
-    // Feed the totem tracker BEFORE the aura gate below — a totem summon
-    // applies no aura, so it would otherwise be dropped. Player casts only.
-    if (caster == Unit::Identity::PlayerGuid())
+    // Feed the totem tracker + fire UNIT_SPELLCAST_SUCCEEDED BEFORE the aura
+    // gate below — a totem summon (and any non-aura spell) applies no aura,
+    // so it would otherwise be dropped. SPELL_GO is "the spell went off", so
+    // this is the succeeded signal for instants too. Player casts only.
+    if (caster == Unit::Identity::PlayerGuid()) {
         Totem::Tracker::OnPlayerSpellGo(spellId);
+        Spell::CastEvents::OnPlayerSucceeded(static_cast<int>(spellId));
+    }
 
     // Mirror server-side duration edits the client is never told about
     // (Conflagrate -3s Immolate, Molten Blast refresh Flame Shock, …). Runs

--- a/src/event/Custom.cpp
+++ b/src/event/Custom.cpp
@@ -282,6 +282,22 @@ int LookupByName(const char *name) {
     return -1;
 }
 
+bool HasListeners(int slot) {
+    if (slot < 0)
+        return false;
+    auto *base = *reinterpret_cast<uint8_t **>(Offsets::VAR_EVENT_TABLE_BASE_PTR);
+    const int count = *reinterpret_cast<int *>(Offsets::VAR_EVENT_TABLE_COUNT);
+    if (base == nullptr || slot >= count)
+        return false;
+    // The entry's chain head (`+0x0C`): a populated subscriber chain is a
+    // non-zero pointer with the low bit clear; `0` or an odd (tagged)
+    // value is the empty self-sentinel — same test the grow-safety scan
+    // uses. So this is true iff at least one frame registered for the event.
+    const uint32_t head = *reinterpret_cast<const uint32_t *>(
+        base + slot * Offsets::EVENT_ENTRY_STRIDE + Offsets::OFF_EVENT_ENTRY_HEAD);
+    return head != 0 && (head & 1) == 0;
+}
+
 void RetryClaims() {
     // Grow the table first if the low gap pool is short (dormant valve).
     // Runs at most once per table build; on the first call every chain is

--- a/src/event/Custom.h
+++ b/src/event/Custom.h
@@ -64,6 +64,15 @@ int Lookup(const char *name);
 // fire ourselves (e.g., polyfilling missing event dispatches).
 int LookupByName(const char *name);
 
+// True iff at least one frame is currently registered for the event in
+// `slot` (its subscriber chain is non-empty). Reads the entry's chain
+// head at `+0x0C` — a couple of pointer derefs, no allocation. Use this
+// to gate expensive per-fire work (arg synthesis, DBC lookups) so an
+// event nobody listens to costs almost nothing: `if (HasListeners(slot))
+// { …build args…; Fire(slot, …); }`. `false` for `slot < 0` or a slot
+// past the live table.
+bool HasListeners(int slot);
+
 // Dispatches a custom event via the engine's printf-style event
 // dispatcher at `FUN_FIRE_EVENT` (`0x00703F50`). `format` is a
 // concatenation of `%d` (int), `%u` (uint), `%f` (double), `%s`

--- a/src/net/SendObserver.cpp
+++ b/src/net/SendObserver.cpp
@@ -1,0 +1,56 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#include "SendObserver.h"
+
+#include "Game.h"
+#include "Offsets.h"
+
+namespace Net::SendObserver {
+
+namespace {
+
+AutoSubscribe *g_head = nullptr;
+
+// `FUN_NET_SEND` — `__thiscall(conn, CDataStore*)`, rendered here as
+// `__fastcall(conn /*ecx*/, edx, packet)`. The leading u32 of the buffer is
+// the opcode.
+using NetSend_t = void(__fastcall *)(void *conn, void *edx, CDataStore *packet);
+NetSend_t g_origNetSend = nullptr;
+
+void __fastcall NetSend_h(void *conn, void *edx, CDataStore *packet) {
+    if (packet != nullptr && g_head != nullptr) {
+        const uint32_t saved = packet->m_read;
+        const uint32_t opcode = Net::Read<uint32_t>(packet);
+        const uint32_t afterOpcode = packet->m_read;
+        for (auto *node = g_head; node != nullptr; node = node->next) {
+            packet->m_read = afterOpcode; // each subscriber reads independently
+            node->cb(opcode, packet);
+        }
+        packet->m_read = saved; // hand the engine an untouched cursor
+    }
+    g_origNetSend(conn, edx, packet);
+}
+
+} // namespace
+
+AutoSubscribe::AutoSubscribe(Callback cb) : cb(cb), next(g_head) {
+    g_head = this;
+}
+
+static const Game::HookAutoRegister _hook{
+    Offsets::FUN_NET_SEND,
+    reinterpret_cast<void *>(&NetSend_h),
+    reinterpret_cast<void **>(&g_origNetSend)};
+
+} // namespace Net::SendObserver

--- a/src/net/SendObserver.h
+++ b/src/net/SendObserver.h
@@ -1,0 +1,44 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+#pragma once
+
+#include "net/PacketReader.h"
+
+#include <cstdint>
+
+// Shared observer for outgoing packets. The engine's NetClient send funnel
+// (`FUN_NET_SEND`) is a general chokepoint every dispatched CMSG passes
+// through — not something a single feature should own. MinHook permits one
+// hook per target, so any module that wants to watch sent packets subscribes
+// here instead of hooking the funnel itself.
+//
+// Mirrors `Tick::WorldTick`: declare a file-scope
+// `static const Net::SendObserver::AutoSubscribe _sub{&callback};`. The
+// constructor chains onto the internal list at static-init time.
+//
+// Each subscriber's callback receives the leading `opcode` (u32) already
+// read, and the `CDataStore` positioned **right after the opcode** so it can
+// read the message body directly. The observer resets that cursor before
+// every subscriber (so they read independently) and restores the original
+// `m_read` before handing the packet to the engine. Callbacks must only
+// READ — never mutate the packet.
+
+namespace Net::SendObserver {
+
+using Callback = void (*)(uint32_t opcode, CDataStore *packet);
+
+struct AutoSubscribe {
+    explicit AutoSubscribe(Callback cb);
+    Callback cb;
+    AutoSubscribe *next;
+};
+
+} // namespace Net::SendObserver

--- a/src/spell/Cast.cpp
+++ b/src/spell/Cast.cpp
@@ -233,8 +233,10 @@ const char *SpellIconPath(const uint8_t *rec) {
 }
 
 // Pushes UnitCastingInfo's 11-tuple from a tracked cast, or nothing (nil)
-// if there's no active cast.
-int PushCastInfo(void *L, const TrackedSpell &c) {
+// if there's no active cast. `casterGuid` identifies whose cast this is (the
+// player's or a remote unit's) so `castID` can be pulled from Spell::CastEvents
+// — the same castGUID the cast's UNIT_SPELLCAST_* events carry.
+int PushCastInfo(void *L, const TrackedSpell &c, uint64_t casterGuid) {
     if (c.spellID == 0)
         return 0;
     // Self-expire: once the cast window has elapsed, report nothing even if
@@ -253,7 +255,12 @@ int PushCastInfo(void *L, const TrackedSpell &c) {
     PushMs(L, c.startMs);                                    // 4 startTimeMs
     PushMs(L, c.endMs);                                      // 5 endTimeMs
     Game::Lua::PushBool(L, IsTradeskill(rec));               // 6 isTradeskill
-    Game::Lua::PushNil(L);                                   // 7 castID
+    char castGuid[48];                                       // 7 castID
+    if (Spell::CastEvents::CurrentCastGuid(casterGuid, c.spellID, castGuid,
+                                           sizeof castGuid))
+        Game::Lua::PushString(L, castGuid);
+    else
+        Game::Lua::PushNil(L);
     Game::Lua::PushBool(L, false);                           // 8 notInterruptible
     Game::Lua::PushNumber(L, static_cast<double>(c.spellID)); // 9 castingSpellID
     Game::Lua::PushNil(L);                                   // 10 castBarID
@@ -798,7 +805,9 @@ void OnWorldTick() {
 static const Tick::WorldTick::AutoSubscribe _tickSub{&OnWorldTick};
 
 // `CastingInfo()` — local player's cast, no token lookup.
-static int __fastcall Script_CastingInfo(void *L) { return PushCastInfo(L, g_cast); }
+static int __fastcall Script_CastingInfo(void *L) {
+    return PushCastInfo(L, g_cast, Unit::Identity::PlayerGuid());
+}
 
 // `UnitCastingInfo(unit)` — local player from self-tracking; other units
 // from the SMSG_SPELL_START cache (regular casts still within their cast
@@ -814,11 +823,13 @@ static int __fastcall Script_UnitCastingInfo(void *L) {
     if (u == nullptr)
         return 0;
     if (u == Resolve("player"))
-        return PushCastInfo(L, g_cast);
+        return PushCastInfo(L, g_cast, Unit::Identity::PlayerGuid());
 
-    const RemoteCast *rc = FindRemoteCast(Unit::Identity::GuidForObject(u));
+    const uint64_t guid = Unit::Identity::GuidForObject(u);
+    const RemoteCast *rc = FindRemoteCast(guid);
     if (rc != nullptr && !rc->isChannel && NowMs() < rc->endMs)
-        return PushCastInfo(L, TrackedSpell{rc->spellID, rc->startMs, rc->endMs});
+        return PushCastInfo(L, TrackedSpell{rc->spellID, rc->startMs, rc->endMs},
+                            guid);
     return 0;
 }
 

--- a/src/spell/Cast.cpp
+++ b/src/spell/Cast.cpp
@@ -800,6 +800,7 @@ void OnWorldTick() {
     Spell::CastEvents::PollPlayer(g_cast.spellID, g_cast.startMs, g_cast.delayMs,
                                   g_channel.spellID, g_channel.startMs);
     Spell::CastEvents::PollRemote();
+    Spell::CastEvents::PollReticle();
 }
 
 static const Tick::WorldTick::AutoSubscribe _tickSub{&OnWorldTick};

--- a/src/spell/Cast.cpp
+++ b/src/spell/Cast.cpp
@@ -470,6 +470,12 @@ void HandleSpellStart(uint64_t caster, int spellID, uint32_t castTime) {
     const int endMs = instantChannel ? now + RemoteChannelDurationMs(rec)
                                      : now + static_cast<int>(castTime);
     StoreRemoteCast(caster, spellID, now, endMs, instantChannel);
+    // Phase 2 events: START (cast) or CHANNEL_START (channel). Skip pure
+    // instants (non-channel, castTime 0 → no bar); their SUCCEEDED still fires
+    // from the SPELL_GO hook.
+    if (castTime > 0 || instantChannel)
+        Spell::CastEvents::OnRemoteCastStart(caster, spellID, endMs,
+                                             instantChannel);
 }
 
 // Co-hook on the SMSG_SPELL_START handler. Gated on opCode 0x131 so every
@@ -619,8 +625,16 @@ void HandleCastAborted(uint64_t guid, int spellID) {
     // clear it on interrupt — this packet is the only signal. Whether the
     // caster receives their own broadcast is server-dependent; if it never
     // fires, the endMs self-expiry backstop still applies.
-    if (guid == Unit::Identity::PlayerGuid() && g_cast.spellID == spellID)
-        g_cast.spellID = 0;
+    if (guid == Unit::Identity::PlayerGuid()) {
+        // Cast interrupts are surfaced by PollPlayer (g_castSucceeded). Player
+        // CHANNELS never fire INTERRUPTED (retail only fires CHANNEL_STOP for
+        // them, interrupted or not), so there's nothing to do for a channel.
+        if (g_cast.spellID == spellID)
+            g_cast.spellID = 0;
+        return;
+    }
+    // Phase 2: remote unit — the poll fires INTERRUPTED + STOP for it.
+    Spell::CastEvents::OnRemoteAborted(guid, spellID);
 }
 
 // Co-hook on the SMSG_SPELL_FAILED_OTHER handler — the server broadcasts it
@@ -778,6 +792,7 @@ void OnWorldTick() {
     // listener-gated (near-free when no addon uses these).
     Spell::CastEvents::PollPlayer(g_cast.spellID, g_cast.startMs, g_cast.delayMs,
                                   g_channel.spellID, g_channel.startMs);
+    Spell::CastEvents::PollRemote();
 }
 
 static const Tick::WorldTick::AutoSubscribe _tickSub{&OnWorldTick};

--- a/src/spell/Cast.cpp
+++ b/src/spell/Cast.cpp
@@ -73,6 +73,7 @@
 #include "dbc/Lookup.h"
 #include "net/PacketReader.h"
 #include "spell/Lookup.h"
+#include "spell/CastEvents.h"
 #include "tick/WorldTick.h"
 #include "unit/Identity.h"
 
@@ -561,6 +562,42 @@ const Game::HookAutoRegister _channelStartHook{
     reinterpret_cast<void *>(&ChannelStart_h),
     reinterpret_cast<void **>(&g_origChannelStart)};
 
+// MSG_CHANNEL_UPDATE (0x006e75f0) — sent to the channeling PLAYER on damage
+// pushback (vanilla channels SHORTEN when hit) and once more at the channel's
+// end (remaining == 0). Body is a single u32 = the new remaining time (ms);
+// the spell is the in-progress channel (the packet carries no spellID, same as
+// the engine's own handler). The engine fires its Lua SPELLCAST_CHANNEL_UPDATE
+// but stores the new end nowhere, so g_channel.endMs — computed once at start —
+// would keep reporting the full, un-pushed-back duration through
+// UnitChannelInfo. Re-anchor it to the server's remaining time so the query
+// (and the OnWorldTick endMs self-expiry) track pushback; on remaining == 0
+// clear the channel so CHANNEL_STOP fires promptly (ahead of the ~1 s-lagged
+// +0x228 field).
+using ChannelUpdate_t = int(__stdcall *)(uint32_t *opCode,
+                                         Net::CDataStore *packet);
+ChannelUpdate_t g_origChannelUpdate = nullptr;
+
+int __stdcall ChannelUpdate_h(uint32_t *opCode, Net::CDataStore *packet) {
+    if (packet != nullptr && g_channel.spellID != 0) {
+        const uint32_t saved = packet->m_read;
+        const uint32_t remaining = Net::Read<uint32_t>(packet);
+        packet->m_read = saved;
+        const int spellID = g_channel.spellID;
+        if (remaining == 0) {
+            g_channel.spellID = 0; // authoritative channel end
+        } else {
+            g_channel.endMs = NowMs() + static_cast<int>(remaining);
+            Spell::CastEvents::OnPlayerChannelUpdate(spellID);
+        }
+    }
+    return g_origChannelUpdate(opCode, packet);
+}
+
+const Game::HookAutoRegister _channelUpdateHook{
+    Offsets::FUN_SPELL_CHANNEL_UPDATE,
+    reinterpret_cast<void *>(&ChannelUpdate_h),
+    reinterpret_cast<void **>(&g_origChannelUpdate)};
+
 // Shared abort handling for the two sibling failure packets. Servers
 // derived from (v)mangos broadcast BOTH `SMSG_SPELL_FAILURE` and
 // `SMSG_SPELL_FAILED_OTHER` from Spell::SendInterrupted, but which one a
@@ -714,7 +751,33 @@ void OnWorldTick() {
             else if (chan == 0 && g_channelConfirmed)
                 g_channel.spellID = 0;
         }
+        // Self-expiry backstop for the poll: the +0x228 broadcast clears ~1
+        // tick (~1s) late, so a channel that runs its full duration would
+        // otherwise linger until then — the poll's CHANNEL_STOP (and any
+        // g_channel reader) would trail the real end by ~1s. Clear at the
+        // server-computed endMs too, so the effective stop is the EARLIER of
+        // (computed end, early +0x228 clear — the summon-ritual / interrupt
+        // case). Mirrors PushChannelInfo's endMs guard, which already hides
+        // the channel from UnitChannelInfo at this same instant.
+        //
+        // Wrap-safe compare: the ms tick (rdtsc-backed, survives reboots) can
+        // sit past 2^31, where a stored endMs reads NEGATIVE as a signed int.
+        // A direct `now >= endMs` would then misfire for a channel straddling
+        // the boundary. The signed DELTA cancels the wrap (correct for any
+        // interval < ~24.8 days — a channel is always far shorter), so test
+        // `now - endMs >= 0` instead.
+        if (g_channel.spellID != 0 && g_channel.endMs != 0 &&
+            NowMs() - g_channel.endMs >= 0)
+            g_channel.spellID = 0;
     }
+
+    // Derive the player's UNIT_SPELLCAST_* events from the cast/channel
+    // state above, now that this tick's clears have been applied. Poll-
+    // based so it needs no changes to the many stamp/clear sites; ~1 frame
+    // latency is imperceptible for a cast bar, and every fire is
+    // listener-gated (near-free when no addon uses these).
+    Spell::CastEvents::PollPlayer(g_cast.spellID, g_cast.startMs, g_cast.delayMs,
+                                  g_channel.spellID, g_channel.startMs);
 }
 
 static const Tick::WorldTick::AutoSubscribe _tickSub{&OnWorldTick};

--- a/src/spell/CastEvents.cpp
+++ b/src/spell/CastEvents.cpp
@@ -43,6 +43,8 @@ constexpr const char *kSucceeded = "UNIT_SPELLCAST_SUCCEEDED";
 constexpr const char *kInterrupted = "UNIT_SPELLCAST_INTERRUPTED";
 constexpr const char *kFailed = "UNIT_SPELLCAST_FAILED";
 constexpr const char *kSent = "UNIT_SPELLCAST_SENT";
+constexpr const char *kReticleTarget = "UNIT_SPELLCAST_RETICLE_TARGET";
+constexpr const char *kReticleClear = "UNIT_SPELLCAST_RETICLE_CLEAR";
 
 const Event::Custom::AutoReserve _rStart{kStart};
 const Event::Custom::AutoReserve _rStop{kStop};
@@ -54,6 +56,8 @@ const Event::Custom::AutoReserve _rSucceeded{kSucceeded};
 const Event::Custom::AutoReserve _rInterrupted{kInterrupted};
 const Event::Custom::AutoReserve _rFailed{kFailed};
 const Event::Custom::AutoReserve _rSent{kSent};
+const Event::Custom::AutoReserve _rReticleTarget{kReticleTarget};
+const Event::Custom::AutoReserve _rReticleClear{kReticleClear};
 
 // Autoshot spams client-side failures while ramping — nampower filters it
 // out of its failure event, so do we.
@@ -135,6 +139,33 @@ void FireSent(int spellID, int guidNum, const char *target) {
                         castGuid, spellID, LocalizedField(rec, OFF_NAME),
                         LocalizedField(rec, OFF_RANK));
 }
+
+// Fire a RETICLE event `(unitTarget, castGUID, spellID, spellName, rank)`.
+// There's no cast yet, so the castGUID slot is empty — retail pushes `nil`
+// there, but the engine's event dispatcher can't emit a nil mid-format (a
+// NULL `%s` corrupts every arg after it — the nil trick only survives as the
+// LAST arg), so we push `""` instead. `unit` (arg1) and `spellID` (arg3) —
+// the load-bearing fields — are exact; only arg2 differs (`""` vs `nil`),
+// which is inconsequential for a reticle (no cast to identify). spellName /
+// rank are our usual extension tail.
+void FireReticle(const char *eventName, int spellID) {
+    const int slot = Event::Custom::Lookup(eventName);
+    if (!Event::Custom::HasListeners(slot))
+        return;
+    const uint8_t *rec = Spell::Lookup::RecordForID(spellID);
+    if (rec == nullptr)
+        return;
+    Event::Custom::Fire(slot, "%s%s%d%s%s", "player", "", spellID,
+                        LocalizedField(rec, OFF_NAME),
+                        LocalizedField(rec, OFF_RANK));
+}
+
+// spellID whose reticle we last reported active (0 = no reticle up).
+int s_reticleSpell = 0;
+// Set when the reticle spell is actually cast (a CMSG_CAST_SPELL for it went
+// out) — so the reticle is clearing by PLACEMENT, and RETICLE_CLEAR is
+// suppressed (retail fires CLEAR only on a real cancel).
+bool s_reticlePlaced = false;
 
 // --- Previous-frame snapshot of the player's cast/channel --------------
 
@@ -284,6 +315,11 @@ void OnSend(uint32_t opcode, Net::CDataStore *packet) {
     const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
     if (spellID == 0)
         return;
+    // If this is the spell whose reticle is up, the player just PLACED it —
+    // the reticle will clear by placement, not cancel, so suppress its
+    // RETICLE_CLEAR (retail fires CLEAR only on a real cancel).
+    if (s_reticleSpell != 0 && spellID == s_reticleSpell)
+        s_reticlePlaced = true;
     // CMSG_CAST_SPELL body after spellId is SpellCastTargets: targetMask
     // (u16), then a packed unit GUID when the UNIT flag is set (self /
     // no-target casts carry none). Resolve that GUID to a unit token for
@@ -470,6 +506,34 @@ void OnPlayerSucceeded(int spellID) {
         guid = NextCastGuid(spellID); // instant — pairs with its SENT
     }
     Fire(kSucceeded, spellID, guid);
+}
+
+void PollReticle() {
+    const bool active =
+        *reinterpret_cast<const int *>(Offsets::VAR_SPELL_TARGETING_FLAGS) != 0;
+    if (active) {
+        if (s_reticleSpell == 0) {
+            // Reticle just came up — report the pending spell. Read the spellID
+            // now (it's set by Spell_C_CastSpell before targeting begins); if
+            // it's transiently 0 this frame, retry next tick.
+            const int spellID =
+                *reinterpret_cast<const int *>(Offsets::VAR_PENDING_CAST_SPELL);
+            if (spellID != 0) {
+                s_reticleSpell = spellID;
+                s_reticlePlaced = false;
+                FireReticle(kReticleTarget, spellID);
+            }
+        }
+    } else if (s_reticleSpell != 0) {
+        // Reticle cleared. Fire CLEAR only if the spell wasn't cast — i.e. the
+        // player CANCELLED (Esc / right-click). A placement (CMSG_CAST_SPELL
+        // went out, s_reticlePlaced set by OnSend) clears the reticle too but
+        // is not a CLEAR event in retail.
+        if (!s_reticlePlaced)
+            FireReticle(kReticleClear, s_reticleSpell);
+        s_reticleSpell = 0;
+        s_reticlePlaced = false;
+    }
 }
 
 void OnPlayerChannelUpdate(int spellID) {

--- a/src/spell/CastEvents.cpp
+++ b/src/spell/CastEvents.cpp
@@ -68,12 +68,12 @@ const char *LocalizedField(const uint8_t *rec, int fieldOffset) {
 }
 
 // Cast UID for a REAL (Type-3) cast — player and remote alike. Per the retail
-// spell-cast-GUID spec (Wowhead) for non-local-only casts: the low 23 bits
-// are the cast's UNIX-epoch second modulo 2^23, and the higher bits are a
-// counter incrementing for casts observed within the same second (Creature-
-// GUID-like). Type-2 casts — local-only FAILED casts, "failed due to
-// requirements not being met" — use a plain incrementing integer instead
-// (`g_guidCounter`), matching the spec's local-cast rule.
+// spell-cast-GUID spec (warcraft.wiki.gg/wiki/GUID#Cast) for non-local-only
+// casts: the low 23 bits are the cast's UNIX-epoch second modulo 2^23, and the
+// higher bits are a counter incrementing for casts observed within the same
+// second (Creature-GUID-like). Type-2 casts — local-only FAILED casts, "failed
+// due to requirements not being met" — use a plain incrementing integer
+// instead (`g_guidCounter`), matching the spec's local-cast rule.
 int MakeCastUID() {
     const uint32_t nowSec = static_cast<uint32_t>(std::time(nullptr));
     static uint32_t s_lastSec = 0;
@@ -91,7 +91,7 @@ int MakeCastUID() {
 // `Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`.
 // Vanilla can't know server/instance/zone, so those three fields are 0. `type`
 // is 3 for real casts (active abilities, channels — the common case) and 2 for
-// local-only FAILED casts, per Wowhead's type table. The load-bearing parts
+// local-only FAILED casts, per the spec's type table. The load-bearing parts
 // are the spellID (field 6, which addons `strsplit("-")` out) and the unique
 // per-cast castUID (field 7). Same (type, spellID, castUID) for every event of
 // one cast → identical string, so START pairs with STOP.
@@ -261,7 +261,7 @@ void __fastcall SpellFailed_h(uint32_t spellId, int result, int unk1, int unk2,
     // progress, or just ended), that cast's end is already reported by the
     // poll's INTERRUPTED — don't also fire FAILED. Only a failure with NO
     // started cast is a genuine pre-cast rejection (out of range, no mana,
-    // on cooldown) → UNIT_SPELLCAST_FAILED. This is Wowhead's Type 2: a
+    // on cooldown) → UNIT_SPELLCAST_FAILED. This is the spec's Type 2: a
     // local-only cast that never reached the server, so it gets a plain
     // incrementing-integer UID (not the time-based real-cast UID).
     if (g_castSpell == sid || recentCast)
@@ -511,6 +511,29 @@ void OnRemoteSucceeded(uint64_t casterGuid, int spellID) {
     // No tracked cast — an instant (no SMSG_SPELL_START). Nothing precedes it,
     // so fire SUCCEEDED now with a fresh (server-time-based) remote UID.
     FireRemote(kSucceeded, casterGuid, spellID, MakeCastUID());
+}
+
+bool CurrentCastGuid(uint64_t casterGuid, int spellID, char *out,
+                     size_t outSize) {
+    if (casterGuid == 0 || spellID == 0 || out == nullptr)
+        return false;
+    int uid;
+    if (casterGuid == Unit::Identity::PlayerGuid()) {
+        // Player's own cast — the guid PollPlayer minted at START (threaded
+        // from SENT). Channels are excluded (g_chanGuid) — UnitCastingInfo is
+        // cast-only.
+        if (g_castSpell != spellID)
+            return false;
+        uid = g_castGuid;
+    } else {
+        // Remote caster — its live event entry (a channel entry is skipped).
+        const RemoteEvt *e = FindRemoteEvt(casterGuid);
+        if (e == nullptr || e->spellID != spellID || e->isChannel)
+            return false;
+        uid = e->guidNum;
+    }
+    BuildCastGuid(out, outSize, /*type=*/3, spellID, uid);
+    return true;
 }
 
 void OnRemoteAborted(uint64_t casterGuid, int spellID) {

--- a/src/spell/CastEvents.cpp
+++ b/src/spell/CastEvents.cpp
@@ -42,6 +42,7 @@ constexpr const char *kChannelUpdate = "UNIT_SPELLCAST_CHANNEL_UPDATE";
 constexpr const char *kSucceeded = "UNIT_SPELLCAST_SUCCEEDED";
 constexpr const char *kInterrupted = "UNIT_SPELLCAST_INTERRUPTED";
 constexpr const char *kFailed = "UNIT_SPELLCAST_FAILED";
+constexpr const char *kFailedQuiet = "UNIT_SPELLCAST_FAILED_QUIET";
 constexpr const char *kSent = "UNIT_SPELLCAST_SENT";
 constexpr const char *kReticleTarget = "UNIT_SPELLCAST_RETICLE_TARGET";
 constexpr const char *kReticleClear = "UNIT_SPELLCAST_RETICLE_CLEAR";
@@ -55,6 +56,7 @@ const Event::Custom::AutoReserve _rChannelUpdate{kChannelUpdate};
 const Event::Custom::AutoReserve _rSucceeded{kSucceeded};
 const Event::Custom::AutoReserve _rInterrupted{kInterrupted};
 const Event::Custom::AutoReserve _rFailed{kFailed};
+const Event::Custom::AutoReserve _rFailedQuiet{kFailedQuiet};
 const Event::Custom::AutoReserve _rSent{kSent};
 const Event::Custom::AutoReserve _rReticleTarget{kReticleTarget};
 const Event::Custom::AutoReserve _rReticleClear{kReticleClear};
@@ -226,6 +228,24 @@ bool IsInterruptResult(int code) {
            code == kSpellFailedInterruptedCombat || code == kSpellFailedMoving;
 }
 
+// SpellCastResult codes that modern surfaces as UNIT_SPELLCAST_FAILED_QUIET (a
+// suppressed, no-error-text failure) rather than FAILED. This is a fixed
+// whitelist, not a "was an error shown" heuristic: verified against the 3.3.5
+// client's unit-spellcast event dispatch (FUN_007fecc0 selects the QUIET event
+// for exactly CHARMED / DONT_REPORT / SPELL_IN_PROGRESS), then mapped to 1.12's
+// SpellCastResult enum (FUN_006e23e0):
+//   CHARMED (0x14) · DONT_REPORT (0x17) · SPELL_IN_PROGRESS (0x61)
+// SPELL_IN_PROGRESS is the common one — casting while already casting, or a
+// nampower spell-queue rejection.
+constexpr int kSpellFailedCharmed = 20;         // 0x14
+constexpr int kSpellFailedSpellInProgress = 97; // 0x61
+
+bool IsQuietResult(int code) {
+    return code == kSpellFailedCharmed ||
+           code == Offsets::SPELL_FAILED_DONT_REPORT ||
+           code == kSpellFailedSpellInProgress;
+}
+
 // A channel's SUCCEEDED is deferred so it fires AFTER CHANNEL_START, matching
 // modern's order (SENT → CHANNEL_START → SUCCEEDED → CHANNEL_STOP). SPELL_GO
 // (OnPlayerSucceeded) lands a poll before the channel is detected, so instead
@@ -267,10 +287,18 @@ SpellFailed_t g_origSpellFailed = nullptr;
 void __fastcall SpellFailed_h(uint32_t spellId, int result, int unk1, int unk2,
                               int failedByServer) {
     g_origSpellFailed(spellId, result, unk1, unk2, failedByServer);
-    if ((result & 0xFF) == Offsets::SPELL_FAILED_DONT_REPORT ||
-        spellId == kAutoShotSpellId)
-        return;
+    if (spellId == kAutoShotSpellId)
+        return; // autoshot ramp spams client failures — filter (like nampower)
     const int sid = static_cast<int>(spellId);
+    // A "quiet" failure the engine shows NO error text for (already casting,
+    // charmed, spammy retries, reticle cancels, Unleashed-Potential-style fake
+    // fails, …). Modern surfaces those as UNIT_SPELLCAST_FAILED_QUIET rather
+    // than FAILED — see IsQuietResult for the verified 3-code whitelist. Same
+    // type-2 (local-only) castGUID as FAILED.
+    if (IsQuietResult(result & 0xFF)) {
+        Fire(kFailedQuiet, sid, ++g_guidCounter, /*type=*/2);
+        return;
+    }
     const int now = NowMs();
     const bool recentCast =
         g_endedSpell == sid && now - g_endedTMs < kEndWindowMs;

--- a/src/spell/CastEvents.cpp
+++ b/src/spell/CastEvents.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <ctime>
 
 namespace Spell::CastEvents {
 
@@ -66,22 +67,44 @@ const char *LocalizedField(const uint8_t *rec, int fieldOffset) {
     return *reinterpret_cast<const char *const *>(rec + fieldOffset + locale * 4);
 }
 
+// Cast UID for a REAL (Type-3) cast — player and remote alike. Per the retail
+// spell-cast-GUID spec (Wowhead) for non-local-only casts: the low 23 bits
+// are the cast's UNIX-epoch second modulo 2^23, and the higher bits are a
+// counter incrementing for casts observed within the same second (Creature-
+// GUID-like). Type-2 casts — local-only FAILED casts, "failed due to
+// requirements not being met" — use a plain incrementing integer instead
+// (`g_guidCounter`), matching the spec's local-cast rule.
+int MakeCastUID() {
+    const uint32_t nowSec = static_cast<uint32_t>(std::time(nullptr));
+    static uint32_t s_lastSec = 0;
+    static uint32_t s_perSec = 0;
+    if (nowSec == s_lastSec)
+        ++s_perSec;
+    else {
+        s_lastSec = nowSec;
+        s_perSec = 0;
+    }
+    return static_cast<int>((s_perSec << 23) | (nowSec & 0x7FFFFFu));
+}
+
 // Modern-shaped castGUID:
 // `Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`.
-// Vanilla can't know server/instance/zone, so those three fields are 0; the
-// load-bearing parts are the spellID (field 6, which addons `strsplit("-")`
-// out) and the unique per-cast castUID (field 7). Same (spellID, guidNum)
-// for every event of one cast → identical string, so START pairs with STOP.
-void BuildCastGuid(char *out, size_t n, int spellID, int guidNum) {
-    std::snprintf(out, n, "Cast-3-0-0-0-%d-%010X", spellID,
-                  static_cast<unsigned>(guidNum));
+// Vanilla can't know server/instance/zone, so those three fields are 0. `type`
+// is 3 for real casts (active abilities, channels — the common case) and 2 for
+// local-only FAILED casts, per Wowhead's type table. The load-bearing parts
+// are the spellID (field 6, which addons `strsplit("-")` out) and the unique
+// per-cast castUID (field 7). Same (type, spellID, castUID) for every event of
+// one cast → identical string, so START pairs with STOP.
+void BuildCastGuid(char *out, size_t n, int type, int spellID, int castUID) {
+    std::snprintf(out, n, "Cast-%d-0-0-0-%d-%010X", type, spellID,
+                  static_cast<unsigned>(castUID));
 }
 
 // Fire a standard-shape event `(unitTarget, castGUID, spellID, spellName,
 // rank)`. Gated on a listener so an unwatched event does no DBC lookups or
 // string formatting. A null name/rank pushes `nil` through the dispatcher's
 // `lua_pushstring(NULL) → pushnil` tail-jump, which is fine.
-void Fire(const char *eventName, int spellID, int guidNum) {
+void Fire(const char *eventName, int spellID, int guidNum, int type = 3) {
     const int slot = Event::Custom::Lookup(eventName);
     if (!Event::Custom::HasListeners(slot))
         return;
@@ -89,7 +112,7 @@ void Fire(const char *eventName, int spellID, int guidNum) {
     if (rec == nullptr)
         return;
     char castGuid[48];
-    BuildCastGuid(castGuid, sizeof(castGuid), spellID, guidNum);
+    BuildCastGuid(castGuid, sizeof(castGuid), type, spellID, guidNum);
     Event::Custom::Fire(slot, "%s%s%d%s%s", "player", castGuid, spellID,
                         LocalizedField(rec, OFF_NAME),
                         LocalizedField(rec, OFF_RANK));
@@ -107,7 +130,7 @@ void FireSent(int spellID, int guidNum, const char *target) {
     if (rec == nullptr)
         return;
     char castGuid[48];
-    BuildCastGuid(castGuid, sizeof(castGuid), spellID, guidNum);
+    BuildCastGuid(castGuid, sizeof(castGuid), /*type=*/3, spellID, guidNum);
     Event::Custom::Fire(slot, "%s%s%s%d%s%s", "player", target ? target : "",
                         castGuid, spellID, LocalizedField(rec, OFF_NAME),
                         LocalizedField(rec, OFF_RANK));
@@ -115,6 +138,8 @@ void FireSent(int spellID, int guidNum, const char *target) {
 
 // --- Previous-frame snapshot of the player's cast/channel --------------
 
+// Incrementing integer for Type-2 (local-only FAILED) cast UIDs only. Real
+// casts get a time-based UID from `MakeCastUID`.
 int g_guidCounter = 0;
 
 int g_castSpell = 0;   // 0 = not casting
@@ -132,9 +157,10 @@ int g_chanGuid = 0;
 int g_pendingGuid = 0;
 int g_pendingSpell = 0;
 
-// The castGUID counter for a cast of `spellID`: reuse the SENT-minted
-// pending one when it matches (and consume it), else mint fresh. Casts
-// with no observed SENT (some engine-internal paths) just get a fresh guid.
+// The castGUID UID for a real (Type-3) cast of `spellID`: reuse the SENT-
+// minted pending one when it matches (and consume it), else mint a fresh
+// time-based UID. Casts with no observed SENT (some engine-internal paths)
+// just get a fresh one.
 int NextCastGuid(int spellID) {
     if (g_pendingGuid != 0 && g_pendingSpell == spellID) {
         const int g = g_pendingGuid;
@@ -142,7 +168,7 @@ int NextCastGuid(int spellID) {
         g_pendingSpell = 0;
         return g;
     }
-    return ++g_guidCounter;
+    return MakeCastUID();
 }
 
 // Last cast that ended (fired STOP) + when, so SpellFailed_h can tell a
@@ -235,10 +261,12 @@ void __fastcall SpellFailed_h(uint32_t spellId, int result, int unk1, int unk2,
     // progress, or just ended), that cast's end is already reported by the
     // poll's INTERRUPTED — don't also fire FAILED. Only a failure with NO
     // started cast is a genuine pre-cast rejection (out of range, no mana,
-    // on cooldown) → UNIT_SPELLCAST_FAILED.
+    // on cooldown) → UNIT_SPELLCAST_FAILED. This is Wowhead's Type 2: a
+    // local-only cast that never reached the server, so it gets a plain
+    // incrementing-integer UID (not the time-based real-cast UID).
     if (g_castSpell == sid || recentCast)
         return;
-    Fire(kFailed, sid, NextCastGuid(sid));
+    Fire(kFailed, sid, ++g_guidCounter, /*type=*/2);
 }
 
 const Game::HookAutoRegister _failedHook{
@@ -269,13 +297,75 @@ void OnSend(uint32_t opcode, Net::CDataStore *packet) {
         if (targetGuid != 0)
             Unit::Identity::TokenFromGUID(targetGuid, target, sizeof(target));
     }
-    const int guid = ++g_guidCounter;
+    const int guid = MakeCastUID(); // real cast (Type 3) → time-based UID
     g_pendingGuid = guid;
     g_pendingSpell = spellID;
     FireSent(spellID, guid, target);
 }
 
 const Net::SendObserver::AutoSubscribe _sendSub{&OnSend};
+
+// ---- Remote (non-player) unit cast events ------------------------------
+
+// Fire `eventName` for EVERY unit token currently mapping to `casterGuid`.
+// The listener gate + DBC name/rank lookup + castGUID build happen once, then
+// the payload is fanned out per token (`target` / `focus` / `nameplateN` /
+// `party` / `raid` / `mouseover`). Same `(unit, castGUID, spellID, spellName,
+// rank)` shape as the player events, just with a non-"player" unit.
+void FireRemote(const char *eventName, uint64_t casterGuid, int spellID,
+                int guidNum) {
+    const int slot = Event::Custom::Lookup(eventName);
+    if (!Event::Custom::HasListeners(slot))
+        return;
+    const uint8_t *rec = Spell::Lookup::RecordForID(spellID);
+    if (rec == nullptr)
+        return;
+    char tokens[16][32];
+    const int n = Unit::Identity::TokensForGUID(casterGuid, tokens, 16);
+    if (n == 0)
+        return;
+    char castGuid[48];
+    BuildCastGuid(castGuid, sizeof(castGuid), /*type=*/3, spellID, guidNum);
+    const char *name = LocalizedField(rec, OFF_NAME);
+    const char *rank = LocalizedField(rec, OFF_RANK);
+    for (int i = 0; i < n; ++i)
+        Event::Custom::Fire(slot, "%s%s%d%s%s", tokens[i], castGuid, spellID,
+                            name, rank);
+}
+
+// One tracked cast per remote caster (a unit can't cast two at once), fired
+// from the poll so ordering (START -> SUCCEEDED -> STOP) is centralized.
+struct RemoteEvt {
+    uint64_t guid;
+    int spellID;
+    int guidNum;
+    int endMs;
+    bool isChannel;
+    bool pendingStart;  // START/CHANNEL_START not yet fired
+    bool startFired;
+    bool succeeded;     // SPELL_GO seen -> completion, not interrupt
+    bool succeededFired;
+    bool aborted;       // failure packet / ClearCastingSpell seen
+    bool active;
+};
+constexpr int kRemoteEvtSlots = 64;
+RemoteEvt g_remoteEvt[kRemoteEvtSlots];
+
+RemoteEvt *FindRemoteEvt(uint64_t guid) {
+    for (auto &e : g_remoteEvt)
+        if (e.active && e.guid == guid)
+            return &e;
+    return nullptr;
+}
+
+RemoteEvt *AllocRemoteEvt(uint64_t guid) {
+    if (RemoteEvt *existing = FindRemoteEvt(guid))
+        return existing; // replace the caster's prior cast in place
+    for (auto &e : g_remoteEvt)
+        if (!e.active)
+            return &e;
+    return &g_remoteEvt[0]; // pool exhausted (64 casters) — reuse slot 0
+}
 
 } // namespace
 
@@ -325,6 +415,8 @@ void PollPlayer(int castSpellID, int castStartMs, int castDelayMs,
     (void)channelStartMs;
     const bool newChan = channelSpellID != 0 && channelSpellID != g_chanSpell;
     if (g_chanSpell != 0 && (channelSpellID == 0 || newChan)) {
+        // Channels only ever fire CHANNEL_STOP — never INTERRUPTED — whether
+        // they end naturally or are cut short (retail behavior, verified).
         Fire(kChannelStop, g_chanSpell, g_chanGuid);
         g_chanSpell = 0;
     }
@@ -389,6 +481,100 @@ void OnPlayerChannelUpdate(int spellID) {
     if (spellID == 0 || g_chanSpell != spellID)
         return;
     Fire(kChannelUpdate, spellID, g_chanGuid);
+}
+
+// ---- Remote unit entry points ------------------------------------------
+
+void OnRemoteCastStart(uint64_t casterGuid, int spellID, int endMs,
+                       bool isChannel) {
+    if (casterGuid == 0 || spellID == 0)
+        return;
+    RemoteEvt *e = AllocRemoteEvt(casterGuid);
+    *e = RemoteEvt{};
+    e->guid = casterGuid;
+    e->spellID = spellID;
+    e->guidNum = MakeCastUID();
+    e->endMs = endMs;
+    e->isChannel = isChannel;
+    e->pendingStart = true;
+    e->active = true;
+}
+
+void OnRemoteSucceeded(uint64_t casterGuid, int spellID) {
+    if (casterGuid == 0 || spellID == 0)
+        return;
+    RemoteEvt *e = FindRemoteEvt(casterGuid);
+    if (e != nullptr && e->spellID == spellID) {
+        e->succeeded = true; // poll fires SUCCEEDED (then STOP) in order
+        return;
+    }
+    // No tracked cast — an instant (no SMSG_SPELL_START). Nothing precedes it,
+    // so fire SUCCEEDED now with a fresh (server-time-based) remote UID.
+    FireRemote(kSucceeded, casterGuid, spellID, MakeCastUID());
+}
+
+void OnRemoteAborted(uint64_t casterGuid, int spellID) {
+    if (casterGuid == 0 || spellID == 0)
+        return;
+    RemoteEvt *e = FindRemoteEvt(casterGuid);
+    if (e != nullptr && e->spellID == spellID)
+        e->aborted = true; // poll fires INTERRUPTED + STOP next frame
+}
+
+void PollRemote() {
+    const int now = NowMs();
+    for (auto &e : g_remoteEvt) {
+        if (!e.active)
+            continue;
+
+        // 1. START / CHANNEL_START.
+        if (e.pendingStart) {
+            FireRemote(e.isChannel ? kChannelStart : kStart, e.guid, e.spellID,
+                       e.guidNum);
+            e.pendingStart = false;
+            e.startFired = true;
+        }
+
+        // 2. SUCCEEDED (SPELL_GO seen). A regular cast completes here (STOP
+        //    follows immediately); a channel keeps running to its endMs.
+        if (e.succeeded && !e.succeededFired) {
+            FireRemote(kSucceeded, e.guid, e.spellID, e.guidNum);
+            e.succeededFired = true;
+            if (!e.isChannel) {
+                FireRemote(kStop, e.guid, e.spellID, e.guidNum);
+                e.active = false;
+                continue;
+            }
+            // A channel's SPELL_GO (which just set `succeeded`) also drives the
+            // engine's cast→channel `ClearCastingSpell` in the same packet
+            // batch — our abort hook sees that. It's the channel STARTING, not
+            // an interrupt, so drop the same-batch abort; otherwise the channel
+            // is killed at its own start. A genuine interrupt lands on a later
+            // poll, when `succeededFired` is already set, so it's still honored.
+            e.aborted = false;
+        }
+
+        // 3. Abort (kick / LoS / death / movement). A cut-short CAST fires
+        //    INTERRUPTED then STOP; a CHANNEL fires only CHANNEL_STOP (retail
+        //    never emits INTERRUPTED for channels, ended early or not — so the
+        //    caster and observer match).
+        if (e.aborted) {
+            if (e.startFired && !e.isChannel)
+                FireRemote(kInterrupted, e.guid, e.spellID, e.guidNum);
+            FireRemote(e.isChannel ? kChannelStop : kStop, e.guid, e.spellID,
+                       e.guidNum);
+            e.active = false;
+            continue;
+        }
+
+        // 4. Natural end at the computed time — the STOP for a channel, and
+        //    the backstop for a cast whose SPELL_GO we never saw.
+        if (e.endMs != 0 && now - e.endMs >= 0) {
+            FireRemote(e.isChannel ? kChannelStop : kStop, e.guid, e.spellID,
+                       e.guidNum);
+            e.active = false;
+        }
+    }
 }
 
 } // namespace Spell::CastEvents

--- a/src/spell/CastEvents.cpp
+++ b/src/spell/CastEvents.cpp
@@ -1,0 +1,394 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#include "CastEvents.h"
+
+#include "Game.h"
+#include "Offsets.h"
+#include "event/Custom.h"
+#include "net/PacketReader.h"
+#include "net/SendObserver.h"
+#include "spell/Lookup.h"
+#include "unit/Identity.h"
+
+#include <cstdio>
+#include <cstdint>
+
+namespace Spell::CastEvents {
+
+namespace {
+
+// Spell.dbc localized string arrays (9 locale slots, 4 bytes each).
+constexpr int OFF_NAME = 0x1E0; // Name[9]
+constexpr int OFF_RANK = 0x204; // Rank[9]
+
+constexpr const char *kStart = "UNIT_SPELLCAST_START";
+constexpr const char *kStop = "UNIT_SPELLCAST_STOP";
+constexpr const char *kDelayed = "UNIT_SPELLCAST_DELAYED";
+constexpr const char *kChannelStart = "UNIT_SPELLCAST_CHANNEL_START";
+constexpr const char *kChannelStop = "UNIT_SPELLCAST_CHANNEL_STOP";
+constexpr const char *kChannelUpdate = "UNIT_SPELLCAST_CHANNEL_UPDATE";
+constexpr const char *kSucceeded = "UNIT_SPELLCAST_SUCCEEDED";
+constexpr const char *kInterrupted = "UNIT_SPELLCAST_INTERRUPTED";
+constexpr const char *kFailed = "UNIT_SPELLCAST_FAILED";
+constexpr const char *kSent = "UNIT_SPELLCAST_SENT";
+
+const Event::Custom::AutoReserve _rStart{kStart};
+const Event::Custom::AutoReserve _rStop{kStop};
+const Event::Custom::AutoReserve _rDelayed{kDelayed};
+const Event::Custom::AutoReserve _rChannelStart{kChannelStart};
+const Event::Custom::AutoReserve _rChannelStop{kChannelStop};
+const Event::Custom::AutoReserve _rChannelUpdate{kChannelUpdate};
+const Event::Custom::AutoReserve _rSucceeded{kSucceeded};
+const Event::Custom::AutoReserve _rInterrupted{kInterrupted};
+const Event::Custom::AutoReserve _rFailed{kFailed};
+const Event::Custom::AutoReserve _rSent{kSent};
+
+// Autoshot spams client-side failures while ramping — nampower filters it
+// out of its failure event, so do we.
+constexpr uint32_t kAutoShotSpellId = 75;
+
+// SpellCastTargets mask bit for a unit target (a packed GUID follows).
+constexpr uint16_t kTargetFlagUnit = 0x0002;
+
+const char *LocalizedField(const uint8_t *rec, int fieldOffset) {
+    const int locale = *reinterpret_cast<int *>(Offsets::VAR_LOCALE_INDEX);
+    return *reinterpret_cast<const char *const *>(rec + fieldOffset + locale * 4);
+}
+
+// Modern-shaped castGUID:
+// `Cast-<type>-<serverID>-<instanceID>-<zoneUID>-<spellID>-<castUID>`.
+// Vanilla can't know server/instance/zone, so those three fields are 0; the
+// load-bearing parts are the spellID (field 6, which addons `strsplit("-")`
+// out) and the unique per-cast castUID (field 7). Same (spellID, guidNum)
+// for every event of one cast → identical string, so START pairs with STOP.
+void BuildCastGuid(char *out, size_t n, int spellID, int guidNum) {
+    std::snprintf(out, n, "Cast-3-0-0-0-%d-%010X", spellID,
+                  static_cast<unsigned>(guidNum));
+}
+
+// Fire a standard-shape event `(unitTarget, castGUID, spellID, spellName,
+// rank)`. Gated on a listener so an unwatched event does no DBC lookups or
+// string formatting. A null name/rank pushes `nil` through the dispatcher's
+// `lua_pushstring(NULL) → pushnil` tail-jump, which is fine.
+void Fire(const char *eventName, int spellID, int guidNum) {
+    const int slot = Event::Custom::Lookup(eventName);
+    if (!Event::Custom::HasListeners(slot))
+        return;
+    const uint8_t *rec = Spell::Lookup::RecordForID(spellID);
+    if (rec == nullptr)
+        return;
+    char castGuid[48];
+    BuildCastGuid(castGuid, sizeof(castGuid), spellID, guidNum);
+    Event::Custom::Fire(slot, "%s%s%d%s%s", "player", castGuid, spellID,
+                        LocalizedField(rec, OFF_NAME),
+                        LocalizedField(rec, OFF_RANK));
+}
+
+// SENT is the one event whose shape differs from the rest, matching modern:
+// `(unitTarget, target, castGUID, spellID, spellName, rank)` — the target is
+// inserted at arg2. `target` is a unit token (e.g. "target") resolved from
+// the cast packet, or "" for self / no-target casts.
+void FireSent(int spellID, int guidNum, const char *target) {
+    const int slot = Event::Custom::Lookup(kSent);
+    if (!Event::Custom::HasListeners(slot))
+        return;
+    const uint8_t *rec = Spell::Lookup::RecordForID(spellID);
+    if (rec == nullptr)
+        return;
+    char castGuid[48];
+    BuildCastGuid(castGuid, sizeof(castGuid), spellID, guidNum);
+    Event::Custom::Fire(slot, "%s%s%s%d%s%s", "player", target ? target : "",
+                        castGuid, spellID, LocalizedField(rec, OFF_NAME),
+                        LocalizedField(rec, OFF_RANK));
+}
+
+// --- Previous-frame snapshot of the player's cast/channel --------------
+
+int g_guidCounter = 0;
+
+int g_castSpell = 0;   // 0 = not casting
+int g_castStart = 0;   // startMs of the tracked cast (detects same-spell recast)
+int g_castGuid = 0;    // castGUID counter value for the tracked cast
+int g_castDelay = 0;   // last-seen accumulated pushback (ms)
+bool g_castSucceeded = false; // SPELL_GO seen for the tracked cast this cast
+
+int g_chanSpell = 0;
+int g_chanGuid = 0;
+
+// castGUID minted at SENT, pending until the matching downstream event
+// (START / SUCCEEDED / FAILED for the same spell) consumes it — so all of
+// a cast's events share one guid. 0 = none pending.
+int g_pendingGuid = 0;
+int g_pendingSpell = 0;
+
+// The castGUID counter for a cast of `spellID`: reuse the SENT-minted
+// pending one when it matches (and consume it), else mint fresh. Casts
+// with no observed SENT (some engine-internal paths) just get a fresh guid.
+int NextCastGuid(int spellID) {
+    if (g_pendingGuid != 0 && g_pendingSpell == spellID) {
+        const int g = g_pendingGuid;
+        g_pendingGuid = 0;
+        g_pendingSpell = 0;
+        return g;
+    }
+    return ++g_guidCounter;
+}
+
+// Last cast that ended (fired STOP) + when, so SpellFailed_h can tell a
+// mid-cast interruption (a started cast that's now aborting — the poll owns
+// its INTERRUPTED) from a genuine pre-cast failure. The window covers the
+// race where the poll's cast-end runs a frame before the engine's
+// Spell_C_SpellFailed for the same cancel.
+int g_endedSpell = 0;
+int g_endedTMs = 0;
+int g_endedGuid = 0;
+constexpr int kEndWindowMs = 1000;
+
+// SpellCastResult codes (nampower's game::SpellCastResult) that mean the
+// cast is being INTERRUPTED rather than failing to start. Movement is the
+// common one: while you hold the cast key and keep moving, the client
+// retries and hits Spell_C_SpellFailed(MOVING) each time — modern surfaces
+// each as a repeated UNIT_SPELLCAST_INTERRUPTED reusing the cast's guid.
+constexpr int kSpellFailedInterrupted = 35;       // 0x23
+constexpr int kSpellFailedInterruptedCombat = 36; // 0x24
+constexpr int kSpellFailedMoving = 46;            // 0x2E
+
+bool IsInterruptResult(int code) {
+    return code == kSpellFailedInterrupted ||
+           code == kSpellFailedInterruptedCombat || code == kSpellFailedMoving;
+}
+
+// A channel's SUCCEEDED is deferred so it fires AFTER CHANNEL_START, matching
+// modern's order (SENT → CHANNEL_START → SUCCEEDED → CHANNEL_STOP). SPELL_GO
+// (OnPlayerSucceeded) lands a poll before the channel is detected, so instead
+// of firing SUCCEEDED there it stashes the channel spell here; PollPlayer
+// fires it with the channel's guid immediately after CHANNEL_START. The window
+// is a loss guard — if no CHANNEL_START ever claims it, the poll fires it
+// standalone rather than dropping it.
+int g_pendingChanSuccSpell = 0;
+int g_pendingChanSuccTMs = 0;
+constexpr int kChanSuccDeferMs = 500;
+
+// Spell.dbc AttributesEx channel bits — same test Spell::Cast uses.
+constexpr int OFF_ATTRIBUTES_EX = 0x1C;
+constexpr uint32_t SPELL_ATTR_EX_CHANNELED = 0x4 | 0x40; // IS_CHANNELED | SELF
+
+bool IsChanneledSpell(int spellID) {
+    const uint8_t *rec = Spell::Lookup::RecordForID(spellID);
+    return rec != nullptr &&
+           (*reinterpret_cast<const uint32_t *>(rec + OFF_ATTRIBUTES_EX) &
+            SPELL_ATTR_EX_CHANNELED) != 0;
+}
+
+int NowMs() {
+    using TickMs_t = uint32_t(__fastcall *)();
+    return static_cast<int>(reinterpret_cast<TickMs_t>(
+        static_cast<uintptr_t>(Offsets::FUN_OS_TICKCOUNT_MS))());
+}
+
+// ---- UNIT_SPELLCAST_FAILED (client-side cast rejection) ----------------
+// Co-hook `Spell_C_SpellFailed` — the local player's own cast failures
+// (out of range, no mana, not-ready, LoS, …). Recipe (hook point +
+// filters) from nampower's Spell_C_SpellFailedHook. We don't hook the
+// SMSG failure PACKET handlers here (Spell::Cast owns those for its cache
+// eviction); this is the distinct client-side entry.
+using SpellFailed_t = void(__fastcall *)(uint32_t spellId, int result,
+                                         int unk1, int unk2, int failedByServer);
+SpellFailed_t g_origSpellFailed = nullptr;
+
+void __fastcall SpellFailed_h(uint32_t spellId, int result, int unk1, int unk2,
+                              int failedByServer) {
+    g_origSpellFailed(spellId, result, unk1, unk2, failedByServer);
+    if ((result & 0xFF) == Offsets::SPELL_FAILED_DONT_REPORT ||
+        spellId == kAutoShotSpellId)
+        return;
+    const int sid = static_cast<int>(spellId);
+    const int now = NowMs();
+    const bool recentCast =
+        g_endedSpell == sid && now - g_endedTMs < kEndWindowMs;
+
+    // Interrupt-class result (moving / kicked): this is the cast being
+    // INTERRUPTED, not failing to start. Modern re-fires INTERRUPTED for
+    // each such retry while you hold the cast key + keep moving, all reusing
+    // the interrupted cast's castGUID. Match that: fire INTERRUPTED with the
+    // in-progress guid, or the just-ended cast's guid, or a fresh one.
+    if (IsInterruptResult(result & 0xFF)) {
+        int guid = g_castSpell == sid ? g_castGuid
+                   : recentCast       ? g_endedGuid
+                                      : NextCastGuid(sid);
+        Fire(kInterrupted, sid, guid);
+        return;
+    }
+
+    // Non-interrupt failure. If it's for a cast that was started (in
+    // progress, or just ended), that cast's end is already reported by the
+    // poll's INTERRUPTED — don't also fire FAILED. Only a failure with NO
+    // started cast is a genuine pre-cast rejection (out of range, no mana,
+    // on cooldown) → UNIT_SPELLCAST_FAILED.
+    if (g_castSpell == sid || recentCast)
+        return;
+    Fire(kFailed, sid, NextCastGuid(sid));
+}
+
+const Game::HookAutoRegister _failedHook{
+    Offsets::FUN_SPELL_C_SPELL_FAILED,
+    reinterpret_cast<void *>(&SpellFailed_h),
+    reinterpret_cast<void **>(&g_origSpellFailed)};
+
+// ---- UNIT_SPELLCAST_SENT (CMSG_CAST_SPELL leaving the client) ----------
+// Watch outgoing sends via the shared observer (no funnel hook of our own).
+// This is the earliest point in a cast's life: mint the castGUID here and
+// stash it pending so the matching START / SUCCEEDED / FAILED reuse it.
+void OnSend(uint32_t opcode, Net::CDataStore *packet) {
+    if (opcode != Offsets::OP_CMSG_CAST_SPELL)
+        return;
+    const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
+    if (spellID == 0)
+        return;
+    // CMSG_CAST_SPELL body after spellId is SpellCastTargets: targetMask
+    // (u16), then a packed unit GUID when the UNIT flag is set (self /
+    // no-target casts carry none). Resolve that GUID to a unit token for
+    // SENT's `target` arg. Layout confirmed against the server's
+    // SpellCastTargets::read (tortoise-wow).
+    char target[64];
+    target[0] = '\0';
+    const uint16_t mask = Net::Read<uint16_t>(packet);
+    if (mask & kTargetFlagUnit) {
+        const uint64_t targetGuid = Net::ReadPackedGuid(packet);
+        if (targetGuid != 0)
+            Unit::Identity::TokenFromGUID(targetGuid, target, sizeof(target));
+    }
+    const int guid = ++g_guidCounter;
+    g_pendingGuid = guid;
+    g_pendingSpell = spellID;
+    FireSent(spellID, guid, target);
+}
+
+const Net::SendObserver::AutoSubscribe _sendSub{&OnSend};
+
+} // namespace
+
+void PollPlayer(int castSpellID, int castStartMs, int castDelayMs,
+                int channelSpellID, int channelStartMs) {
+    // ---- Regular cast -------------------------------------------------
+    // A "new cast" is a different spell OR the same spell re-stamped at a
+    // new start time (a chained same-spell recast — the engine bails
+    // Spell_C_CastSpell on `spellID == current`, so only the fresh startMs
+    // distinguishes it). Fire STOP for the outgoing cast first, then START.
+    const bool newCast = castSpellID != 0 &&
+                         (castSpellID != g_castSpell || castStartMs != g_castStart);
+    if (g_castSpell != 0 && (castSpellID == 0 || newCast)) {
+        // A cast that ended without a SPELL_GO for it was interrupted /
+        // cancelled — fire INTERRUPTED before STOP. By this tick, a natural
+        // completion's SPELL_GO (and thus OnPlayerSucceeded) has already run
+        // a frame earlier, so the flag reliably tells the two apart even
+        // though the engine routes both through the same abort choke point.
+        if (!g_castSucceeded)
+            Fire(kInterrupted, g_castSpell, g_castGuid);
+        Fire(kStop, g_castSpell, g_castGuid);
+        g_endedSpell = g_castSpell; // for SpellFailed_h's interrupt-vs-fail gate
+        g_endedGuid = g_castGuid;   // repeated movement-interrupts reuse it
+        g_endedTMs = NowMs();
+        g_castSpell = 0;
+    }
+    if (newCast) {
+        g_castGuid = NextCastGuid(castSpellID);
+        g_castSpell = castSpellID;
+        g_castStart = castStartMs;
+        g_castDelay = castDelayMs;
+        g_castSucceeded = false;
+        Fire(kStart, castSpellID, g_castGuid);
+    } else if (g_castSpell != 0 && castDelayMs > g_castDelay) {
+        // Pushback grew (SMSG_SPELL_DELAYED extended the cast).
+        g_castDelay = castDelayMs;
+        Fire(kDelayed, g_castSpell, g_castGuid);
+    }
+
+    // ---- Channel ------------------------------------------------------
+    // Detect a new channel by spellID ONLY (not startMs): a channel is
+    // stamped twice at start — SMSG_SPELL_START, then MSG_CHANNEL_START
+    // re-stamps with the server duration — which changes startMs but is the
+    // SAME channel. A startMs check would spuriously fire STOP+START on the
+    // re-stamp. A genuine re-channel of the same spell passes through
+    // g_chanSpell==0 (CHANNEL_STOP) first, so spellID alone still catches it.
+    (void)channelStartMs;
+    const bool newChan = channelSpellID != 0 && channelSpellID != g_chanSpell;
+    if (g_chanSpell != 0 && (channelSpellID == 0 || newChan)) {
+        Fire(kChannelStop, g_chanSpell, g_chanGuid);
+        g_chanSpell = 0;
+    }
+    if (newChan) {
+        // The initiating cast's SENT guid is still pending — a channel's
+        // SUCCEEDED is deferred (OnPlayerSucceeded), so it hasn't consumed the
+        // guid yet. NextCastGuid reuses it, keeping SENT / CHANNEL_START /
+        // SUCCEEDED / CHANNEL_STOP on one castGUID.
+        g_chanGuid = NextCastGuid(channelSpellID);
+        g_chanSpell = channelSpellID;
+        Fire(kChannelStart, channelSpellID, g_chanGuid);
+        // Modern fires SUCCEEDED right after CHANNEL_START. SPELL_GO deferred
+        // it to here so it lands after START, sharing the channel's guid.
+        if (g_pendingChanSuccSpell == channelSpellID) {
+            Fire(kSucceeded, channelSpellID, g_chanGuid);
+            g_pendingChanSuccSpell = 0;
+        }
+    }
+
+    // Loss guard: a deferred channel SUCCEEDED that no CHANNEL_START claimed
+    // within the window (the channel never stamped) fires standalone rather
+    // than being dropped.
+    if (g_pendingChanSuccSpell != 0 &&
+        NowMs() - g_pendingChanSuccTMs >= kChanSuccDeferMs) {
+        Fire(kSucceeded, g_pendingChanSuccSpell,
+             NextCastGuid(g_pendingChanSuccSpell));
+        g_pendingChanSuccSpell = 0;
+    }
+}
+
+void OnPlayerSucceeded(int spellID) {
+    if (spellID == 0)
+        return;
+    // Channels fire SUCCEEDED *after* CHANNEL_START (modern order). This
+    // SPELL_GO lands a poll before the channel is detected, so defer: stash
+    // the spell and let PollPlayer fire SUCCEEDED right after it fires
+    // CHANNEL_START, sharing the channel's guid.
+    if (IsChanneledSpell(spellID)) {
+        g_pendingChanSuccSpell = spellID;
+        g_pendingChanSuccTMs = NowMs();
+        return;
+    }
+    // Non-channel: fire now. Pair with the tracked cast guid when it's the
+    // same spell (cast-time — START already minted the guid); otherwise an
+    // instant with no tracked cast, so mint a fresh one (pairs with its SENT).
+    int guid;
+    if (g_castSpell == spellID) {
+        guid = g_castGuid;
+        g_castSucceeded = true; // marks this cast a completion, not an interrupt
+    } else {
+        guid = NextCastGuid(spellID); // instant — pairs with its SENT
+    }
+    Fire(kSucceeded, spellID, guid);
+}
+
+void OnPlayerChannelUpdate(int spellID) {
+    // Only the tracked, already-started channel gets an UPDATE, reusing its
+    // guid so CHANNEL_START / UPDATE / STOP share one castGUID. A pushback
+    // arrives seconds into a channel — long after the poll fired
+    // CHANNEL_START — so g_chanSpell / g_chanGuid are set by now; if somehow
+    // not, skip (an UPDATE never precedes its START).
+    if (spellID == 0 || g_chanSpell != spellID)
+        return;
+    Fire(kChannelUpdate, spellID, g_chanGuid);
+}
+
+} // namespace Spell::CastEvents

--- a/src/spell/CastEvents.h
+++ b/src/spell/CastEvents.h
@@ -35,6 +35,7 @@
 // registers for these the module costs one pointer-compare per transition
 // and does no arg synthesis.
 
+#include <cstddef>
 #include <cstdint>
 
 namespace Spell::CastEvents {
@@ -69,6 +70,15 @@ void OnPlayerSucceeded(int spellID);
 // `C_Spell.UnitChannelInfo`, matching modern — this event is only the "re-read
 // now" trigger.
 void OnPlayerChannelUpdate(int spellID);
+
+// Write the castGUID string of `casterGuid`'s current CAST of `spellID` into
+// `out` (>= 48 bytes) and return true, or return false if that unit isn't
+// tracked as casting this spell. It's the SAME string the cast's events carry
+// (`SENT`/`START`/…), so `C_Spell.UnitCastingInfo`'s `castID` return can pull
+// it from here and stay consistent with the events. `casterGuid` is the local
+// player's GUID for own casts, or the remote caster's GUID. Channels are
+// excluded (retail's UnitChannelInfo has no castID).
+bool CurrentCastGuid(uint64_t casterGuid, int spellID, char *out, size_t outSize);
 
 // `UNIT_SPELLCAST_SENT` is handled internally — the module subscribes to
 // the shared `Net::SendObserver` and fires it when CMSG_CAST_SPELL leaves

--- a/src/spell/CastEvents.h
+++ b/src/spell/CastEvents.h
@@ -46,6 +46,8 @@ namespace Spell::CastEvents {
 //   - regular cast start / stop / same-spell recast  → UNIT_SPELLCAST_START / _STOP
 //   - accumulated pushback growth                     → UNIT_SPELLCAST_DELAYED
 //   - channel start / stop                            → UNIT_SPELLCAST_CHANNEL_START / _STOP
+// Channels never fire INTERRUPTED — retail emits only CHANNEL_STOP for a
+// channel whether it ends naturally or is cut short.
 void PollPlayer(int castSpellID, int castStartMs, int castDelayMs,
                 int channelSpellID, int channelStartMs);
 
@@ -73,5 +75,45 @@ void OnPlayerChannelUpdate(int spellID);
 // the client (the earliest point in a cast's life). The castGUID minted
 // there threads forward: the matching START / SUCCEEDED / FAILED reuse it,
 // so all of a cast's events share one guid.
+
+// ---- Phase 2: non-player (remote) units --------------------------------
+//
+// Remote casts have a narrower data surface than the player's: vanilla only
+// broadcasts a caster's cast via SMSG_SPELL_START (+ SPELL_GO at completion)
+// and its abort via the failure packets / ClearCastingSpell choke point. So
+// remotes get START / STOP / CHANNEL_START / CHANNEL_STOP / SUCCEEDED /
+// INTERRUPTED, but NOT SENT / DELAYED / FAILED / CHANNEL_UPDATE (that data
+// is caster-only or client-local and never reaches an observer — see the
+// remote-unit limitations in CLAUDE.md).
+//
+// `Spell::Cast` owns the remote-cast packet hooks; it calls these at the
+// transition points, and each event is fanned out to EVERY unit token the
+// caster GUID currently maps to (target / focus / nameplateN / party / raid /
+// mouseover), via `Unit::Identity::TokensForGUID`. Each remote cast gets its
+// own synthesized castGUID, shared across its events.
+
+// A remote unit began a cast (SMSG_SPELL_START). `endMs` is the computed end
+// (server castTime, or channel duration); `isChannel` selects
+// CHANNEL_START/STOP vs START/STOP. Called only for real bars — pure instants
+// (no cast time, not a channel) are skipped by the caller. Fired from the
+// poll so START lands at frame time in the right order.
+void OnRemoteCastStart(uint64_t casterGuid, int spellID, int endMs,
+                       bool isChannel);
+
+// A remote unit's spell went off (SMSG_SPELL_GO). Marks the tracked cast so
+// the poll fires SUCCEEDED (then STOP) in order; if there's no tracked cast
+// (an instant, which sends no SPELL_START) fires SUCCEEDED immediately with a
+// fresh castGUID.
+void OnRemoteSucceeded(uint64_t casterGuid, int spellID);
+
+// A remote unit's cast was aborted (failure packet / ClearCastingSpell). The
+// poll fires INTERRUPTED + STOP (or CHANNEL_STOP) for it next frame.
+void OnRemoteAborted(uint64_t casterGuid, int spellID);
+
+// Per-frame driver for remote cast events — fires START/CHANNEL_START, then
+// SUCCEEDED, then STOP/CHANNEL_STOP/INTERRUPTED in modern order as each
+// tracked remote cast transitions, and expires casts at their computed end.
+// Called from `Spell::Cast::OnWorldTick` after `PollPlayer`.
+void PollRemote();
 
 } // namespace Spell::CastEvents

--- a/src/spell/CastEvents.h
+++ b/src/spell/CastEvents.h
@@ -1,0 +1,77 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+#pragma once
+
+// Backport of the TBC+ `UNIT_SPELLCAST_*` events to 1.12, for the local
+// player. The underlying cast/channel detection already exists in
+// `Spell::Cast` (it hooks every relevant path for `UnitCastingInfo` /
+// `UnitChannelInfo`); this module turns those state transitions into the
+// retail-named Lua events so ported cast-bar / rotation addons work.
+//
+// MinHook allows one hook per target and `Spell::Cast` already owns the
+// cast-related hooks, so this module doesn't hook anything — the hook
+// owners call into it. Cast start/stop/channel/pushback are derived by
+// polling `Spell::Cast`'s player state once per frame (`PollPlayer`,
+// called from that module's `OnWorldTick`); succeeded/interrupted come
+// from the SPELL_GO / abort paths in later slices.
+//
+// Event contract (arg1 is always the unit token):
+//   (unitTarget, castGUID, spellID, spellName, rank)
+// The first three match the modern Classic-Era signature, so addons
+// written against it read `unit, castGUID, spellID` and work; `spellName`
+// / `rank` are ClassicAPI extension tail args. `castGUID` is a synthesized
+// unique-per-cast string ("Cast-<n>") — not retail's GUID format, just
+// stable across a cast's events so START can be paired with STOP.
+//
+// Every fire is gated on `Event::Custom::HasListeners`, so when no addon
+// registers for these the module costs one pointer-compare per transition
+// and does no arg synthesis.
+
+#include <cstdint>
+
+namespace Spell::CastEvents {
+
+// Derive player cast/channel events from a once-per-frame snapshot of
+// `Spell::Cast`'s player state. Called from `Spell::Cast::OnWorldTick`
+// after its own upkeep, passing the live `g_cast` / `g_channel` fields.
+// Detects, against the previous snapshot:
+//   - regular cast start / stop / same-spell recast  → UNIT_SPELLCAST_START / _STOP
+//   - accumulated pushback growth                     → UNIT_SPELLCAST_DELAYED
+//   - channel start / stop                            → UNIT_SPELLCAST_CHANNEL_START / _STOP
+void PollPlayer(int castSpellID, int castStartMs, int castDelayMs,
+                int channelSpellID, int channelStartMs);
+
+// Fire `UNIT_SPELLCAST_SUCCEEDED` for the local player. Called from the
+// SPELL_GO hook (`Aura::Source`) when the caster is the player — that
+// packet is "the spell went off," so it fires for instants (which never
+// touch the cast state above) as well as completed cast-time / channel
+// spells. Reuses the in-flight cast's castGUID when the spellID matches,
+// else mints a fresh one (instant cast). For channels it defers to
+// `PollPlayer`, which fires SUCCEEDED right after CHANNEL_START so the
+// order matches modern (CHANNEL_START → SUCCEEDED).
+void OnPlayerSucceeded(int spellID);
+
+// Fire `UNIT_SPELLCAST_CHANNEL_UPDATE` for the local player. Called from the
+// MSG_CHANNEL_UPDATE hook (`Spell::Cast`) when a pushback re-anchors the
+// player's active channel end. Reuses the tracked channel's castGUID (set by
+// CHANNEL_START); no-ops if the channel isn't tracked yet (an UPDATE never
+// precedes its START). The end time itself is read via
+// `C_Spell.UnitChannelInfo`, matching modern — this event is only the "re-read
+// now" trigger.
+void OnPlayerChannelUpdate(int spellID);
+
+// `UNIT_SPELLCAST_SENT` is handled internally — the module subscribes to
+// the shared `Net::SendObserver` and fires it when CMSG_CAST_SPELL leaves
+// the client (the earliest point in a cast's life). The castGUID minted
+// there threads forward: the matching START / SUCCEEDED / FAILED reuse it,
+// so all of a cast's events share one guid.
+
+} // namespace Spell::CastEvents

--- a/src/spell/CastEvents.h
+++ b/src/spell/CastEvents.h
@@ -52,6 +52,13 @@ namespace Spell::CastEvents {
 void PollPlayer(int castSpellID, int castStartMs, int castDelayMs,
                 int channelSpellID, int channelStartMs);
 
+// Derive the ground-target reticle events from the engine's targeting flags.
+// Called from `Spell::Cast::OnWorldTick`. On the reticle appearing for a
+// ground-targeted spell (Blizzard, Flare, …) fires UNIT_SPELLCAST_RETICLE_TARGET;
+// on it clearing (spell placed or cancelled) fires UNIT_SPELLCAST_RETICLE_CLEAR.
+// Both are `(unitTarget, nil, spellID, spellName, rank)` — always the player.
+void PollReticle();
+
 // Fire `UNIT_SPELLCAST_SUCCEEDED` for the local player. Called from the
 // SPELL_GO hook (`Aura::Source`) when the caster is the player — that
 // packet is "the spell went off," so it fires for instants (which never

--- a/src/unit/Identity.cpp
+++ b/src/unit/Identity.cpp
@@ -328,6 +328,51 @@ const char *TokenFromGUID(uint64_t target, char *buf, size_t bufSize) {
     return nullptr;
 }
 
+int TokensForGUID(uint64_t guid, char (*out)[32], int maxTokens) {
+    if (guid == 0 || out == nullptr || maxTokens <= 0)
+        return 0;
+
+    int n = 0;
+    // Engine-native tokens via the reverse map. It fills a shared static
+    // array and returns its base; snapshot each string into `out` before we
+    // do anything re-entrant. Non-throwing (count 0 pre-world).
+    using TokensFromGuid_t =
+        const char *const *(__fastcall *)(const uint64_t *guid, int *outCount);
+    int nativeCount = 0;
+    const char *const *natives = reinterpret_cast<TokensFromGuid_t>(
+        static_cast<uintptr_t>(Offsets::FUN_UNIT_TOKENS_FROM_GUID))(&guid,
+                                                                    &nativeCount);
+    if (natives != nullptr) {
+        for (int i = 0; i < nativeCount && n < maxTokens; ++i) {
+            const char *tok = natives[i];
+            if (tok == nullptr)
+                continue;
+            // SuperWoW patches this reverse map to ALSO emit the caster's raw
+            // GUID string ("0x…") as a token (it makes GUID strings valid unit
+            // tokens). Skip it — the standard tokens are what retail-compat
+            // addons expect; echoing the GUID we were handed is noise.
+            if (tok[0] == '0' && (tok[1] == 'x' || tok[1] == 'X'))
+                continue;
+            std::snprintf(out[n], 32, "%s", tok);
+            ++n;
+        }
+    }
+
+    // Synthetic tokens the engine's map can't produce. `focus` resolves via
+    // our token-resolver hook (returns 0 when unset — never raises).
+    if (n < maxTokens && GuidForToken("focus") == guid)
+        std::snprintf(out[n++], 32, "focus");
+
+    // Visible nameplates — sparse slot array, so scan and skip gaps.
+    const int plateCount = NamePlate::Events::GetSlotCount();
+    for (int i = 1; i <= plateCount && n < maxTokens; ++i) {
+        if (NamePlate::Events::GetGUIDByIndex(i) == guid)
+            std::snprintf(out[n++], 32, "nameplate%d", i);
+    }
+
+    return n;
+}
+
 static int __fastcall Script_UnitTokenFromGUID(void *L) {
     if (!Game::Lua::IsString(L, 1)) {
         Game::Lua::Error(L, "Usage: UnitTokenFromGUID(\"unitGUID\")");

--- a/src/unit/Identity.h
+++ b/src/unit/Identity.h
@@ -86,6 +86,18 @@ uint64_t GuidForToken(const char *token);
 // `buf` should be at least 32 bytes.
 const char *TokenFromGUID(uint64_t guid, char *buf, size_t bufSize);
 
+// Enumerate EVERY unit token currently mapping to `guid` (not just the
+// first, unlike `TokenFromGUID`). Writes each token string into `out[i]`
+// (each row must hold >= 32 bytes) and returns the count, capped at
+// `maxTokens`. Engine-native tokens (player/pet/target/party/partypet/raid/
+// raidpet/npc/mouseover) come from the engine's reverse map
+// (`FUN_UNIT_TOKENS_FROM_GUID`); ClassicAPI's synthetic `focus` /
+// `nameplateN` are appended on top. The result is snapshotted into `out`
+// (safe to fire re-entrant Lua events while iterating). Returns 0 pre-world
+// or when no token maps to `guid`. Used for the per-token `UNIT_SPELLCAST_*`
+// remote-unit fan-out.
+int TokensForGUID(uint64_t guid, char (*out)[32], int maxTokens);
+
 // The engine's cached player-info record for `guid` — the NameCache data block
 // (name @ `OFF_PLAYER_INFO_NAME`, realm, race @ `_RACE`, sex, class @ `_CLASS`),
 // or null if the GUID isn't cached. Object-independent: it resolves players who

--- a/src/unit/TokenExtensions.cpp
+++ b/src/unit/TokenExtensions.cpp
@@ -27,6 +27,13 @@
 //   See `unit/Focus.cpp` for the storage + `PLAYER_FOCUS_CHANGED`
 //   event firing.
 //
+// - `0x<hex>` — a raw 64-bit GUID literal (SuperWoW's format:
+//   `"0x"` + up to 16 hex digits). Lets every `Unit*` accept a GUID
+//   in place of a token, which is SuperWoW's headline "hard
+//   dependency" feature. Only enabled when SuperWoW is NOT loaded —
+//   when it is, its own resolver hook owns GUID input and we defer to
+//   avoid double-handling. See `GuidTokenEnabled` below.
+//
 // Both families compose with the engine's own `target`-suffix walker
 // (`focustarget`, `nameplate1targettarget`) via the shared
 // `WalkSuffix` helper, which mirrors the engine's
@@ -45,9 +52,35 @@
 
 #include <cstdint>
 
+#include <windows.h>
+
 namespace Unit::TokenExtensions {
 
 namespace {
+
+// SuperWoW (loaded by VanillaFixes from `dlls.txt` as `SuperWoWhook.dll`)
+// already makes the token resolver accept `"0x..."` GUID literals, so we
+// only add it ourselves when SuperWoW is absent — otherwise both would
+// parse the same input. VanillaFixes `LoadLibrary`s every listed DLL during
+// its injection pass, long before this hook installs at game boot, so the
+// module handle is present iff SuperWoW is active. Cached — module presence
+// is fixed for the process lifetime.
+bool GuidTokenEnabled() {
+    static const bool enabled =
+        GetModuleHandleA("SuperWoWhook.dll") == nullptr;
+    return enabled;
+}
+
+// Hex nibble, or -1 for a non-hex character. Case-insensitive.
+int HexNibble(char c) {
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    return -1;
+}
 
 using TokenToGUID_t = uint64_t(__fastcall *)(const char *token);
 // `__stdcall`, not `__cdecl` — `FUN_00064A4C0` ends with `ret 0xc`,
@@ -109,6 +142,25 @@ uint64_t WalkSuffix(uint64_t guid, const char *suffix) {
 uint64_t __fastcall Hook_h(const char *token) {
     if (token == nullptr || *token == '\0')
         return Original_o(token);
+
+    // Raw GUID literal `0x<hex>` (SuperWoW input format). The parsed GUID
+    // is returned straight to the engine's own back-half of the resolver
+    // (`FUN_00468460(unit-mask, guid)`), the identical path `"player"`
+    // takes — so an out-of-range / unloaded GUID resolves to nil exactly
+    // like any absent unit, no special handling. Feeds the same suffix
+    // walker as the other families, so `"0x…target"` composes too.
+    if (GuidTokenEnabled() && token[0] == '0' &&
+        (token[1] == 'x' || token[1] == 'X')) {
+        const char *p = token + 2;
+        uint64_t guid = 0;
+        int digits = 0;
+        for (int nibble; (nibble = HexNibble(*p)) >= 0; ++p) {
+            guid = (guid << 4) | static_cast<uint32_t>(nibble);
+            ++digits;
+        }
+        if (digits > 0)
+            return WalkSuffix(guid, p);
+    }
 
     auto sstrcmpi = reinterpret_cast<SStrCmpI_t>(Offsets::FUN_SSTR_CMP_I);
 


### PR DESCRIPTION
Backports the modern `UNIT_SPELLCAST_*` event family to 1.12.1 (local player + remote units) and adds GUID-literal unit tokens.

## UNIT_SPELLCAST_* events

- **Local player** — `SENT` / `START` / `STOP` / `DELAYED` / `SUCCEEDED` / `INTERRUPTED` / `FAILED` / `FAILED_QUIET` / `CHANNEL_START` / `CHANNEL_UPDATE` / `CHANNEL_STOP`, derived from `Spell::Cast`'s existing cast/channel state with modern event ordering. Channel pushback re-anchors `UnitChannelInfo`'s end time; wrap-safe timing (no negative values on long-uptime machines).
- **Non-player units (phase 2)** — `START` / `STOP` / `CHANNEL_START` / `CHANNEL_STOP` / `SUCCEEDED` / `INTERRUPTED`, recovered from the `SMSG_SPELL_START` packet plus the `CGUnit_C::ClearCastingSpell` choke point, fanned out to every unit token the caster GUID currently maps to (target / focus / nameplateN / party / raid / mouseover).
- **Reticle** — `RETICLE_TARGET` / `RETICLE_CLEAR` for ground-targeted spells.
- **`FAILED` vs `FAILED_QUIET`** — verified against the 3.3.5 client's own unit-spellcast dispatch (a fixed whitelist: `CHARMED` / `DONT_REPORT` / `SPELL_IN_PROGRESS`), mapped to 1.12's `SpellCastResult` enum. `SPELL_IN_PROGRESS` (cast-while-casting / spell-queue rejection) is the common quiet case.
- **castGUID** — synthesized per cast in the documented `Cast-<type>-...` format and returned as `UnitCastingInfo` / `CastingInfo`'s `castID`, consistent across a cast's events.

## GUID unit tokens

- Every `Unit*` function accepts a raw `"0x<hex>"` GUID literal in place of a unit token (folded into the existing `FUN_TOKEN_TO_GUID` hook, so one branch covers the whole surface). Reuses the token suffix walker, so `"0x...target"` composes.
- Gated on SuperWoW's absence (`GetModuleHandleA("SuperWoWhook.dll")`) — SuperWoW already provides GUID input via its own resolver patch, so we defer to it when loaded. Behaves identically either way.

## Testing

In-game on Turtle/Octo 1.12.1: event ordering + channel timing (priest/mage), remote casts and interrupts, `castID` correlation, `FAILED_QUIET` on spam-cast, and GUID-token input verified both with SuperWoW absent (our path) and present (defers to SuperWoW).