### PR TITLE
frame: attribute backport, modern script args, and SMSG hook consolidation

### DIFF
--- a/AddOns/!!!ClassicAPI/!!!ClassicAPI.toc
+++ b/AddOns/!!!ClassicAPI/!!!ClassicAPI.toc
@@ -44,3 +44,4 @@ Util\Vector3D.lua
 Util\Vector4D.lua
 Util\UIParent.lua
 Util\AuraDurationModifiers.lua
+Util\SecureUnitMenu.lua

--- a/AddOns/!!!ClassicAPI/Util/SecureUnitMenu.lua
+++ b/AddOns/!!!ClassicAPI/Util/SecureUnitMenu.lua
@@ -1,0 +1,59 @@
+-- Unit right-click menu for attribute-driven unit frames.
+--
+-- Backs the `menu` / `togglemenu` click verb of the Frame:SetAttribute
+-- backport (see src/frame/Attributes.cpp). When a frame with a `unit`
+-- attribute resolves a click to the `menu` verb, the DLL calls
+-- ClassicAPI_ToggleUnitMenu(unit), which pops the standard unit dropdown at
+-- the cursor -- the same UnitPopup menu Blizzard's PlayerFrame / TargetFrame /
+-- PartyMemberFrame show on right-click. Lets a unit frame express its
+-- right-click menu purely as an attribute (e.g. type2 = "menu") instead of a
+-- hand-rolled OnClick handler.
+--
+-- The unit -> menu-type resolution mirrors Blizzard's own generic resolver
+-- (TargetFrameDropDown_Initialize in FrameXML): self -> SELF, pet -> PET, a
+-- grouped player -> PARTY (whisper / inspect / trade / follow / promote / ...),
+-- any other player -> PLAYER (adds INVITE), anything else (NPC) ->
+-- RAID_TARGET_ICON. Vanilla's stock UI never wires a unit to the "RAID" menu
+-- (there are no clickable raid unit frames in 1.12), and PARTY carries the
+-- options players actually want on a grouped member, so grouped players (party
+-- or raid) use PARTY -- matching how pfUI drives its raid menu.
+
+local dropdown;
+
+local function EnsureDropdown()
+    if not dropdown then
+        dropdown = CreateFrame("Frame", "ClassicAPIUnitMenuDropDown", UIParent, "UIDropDownMenuTemplate");
+        dropdown.displayMode = "MENU";
+    end
+    return dropdown;
+end
+
+local function ResolveMenu(unit)
+    if UnitIsUnit(unit, "player") then
+        return "SELF";
+    elseif UnitIsUnit(unit, "pet") then
+        return "PET";
+    elseif UnitIsPlayer(unit) then
+        if UnitInParty(unit) or UnitInRaid(unit) then
+            return "PARTY";
+        end
+        return "PLAYER";
+    end
+    return "RAID_TARGET_ICON";
+end
+
+function ClassicAPI_ToggleUnitMenu(unit)
+    if not unit or not UnitExists(unit) then
+        return;
+    end
+    local which = ResolveMenu(unit);
+    local name;
+    if which == "RAID_TARGET_ICON" then
+        name = RAID_TARGET_ICON;
+    end
+    local dd = EnsureDropdown();
+    dd.initialize = function()
+        UnitPopup_ShowMenu(dd, which, unit, name);
+    end
+    ToggleDropDownMenu(1, nil, dd, "cursor");
+end

--- a/docs/API.md
+++ b/docs/API.md
@@ -3874,7 +3874,10 @@ modifier unless a modifier-specific attribute (`shift-type1`) overrides it — a
 `spell` attribute and casts it on the unit via the native
 [`C_Spell.CastAtUnit`](#c_spellcastatunitspellidorname-unit) — the unit's GUID is fed straight to
 the cast dispatcher, so there's no target juggling, and ground-target spells
-land at the unit's feet), `macro` (takes the
+land at the unit's feet), `item` (uses the `item` attribute — an item
+name/itemID/link via `C_Item.UseItemByName` with the unit as the use target, or
+a `"bag slot"` string like `"0 1"` via `UseContainerItem`; the deprecated
+`bag`/`slot` attributes also work), `macro` (takes the
 `macrotext`/`macro` attribute and prefers an addon-provided `RunMacro` — e.g.
 SuperCleveRoidMacros, which handles named macros and extended macro text —
 falling back to running the text natively, line by line through the stock

--- a/docs/API.md
+++ b/docs/API.md
@@ -164,6 +164,7 @@ build instructions.
   - [`frame:HookScript(scriptType, handler)`](#framehookscriptscripttype-handler)
   - [`frame:IsEventRegistered(event)`](#frameiseventregisteredevent)
   - [`frame:GetEffectiveAlpha()`](#framegeteffectivealpha)
+  - [`frame:SetAttribute` / `SetAttributeNoHandler` / `GetAttribute` (+ unit-frame mouseover)](#framesetattributename-value--framesetattributenohandlername-value--framegetattribute)
 
 - [FriendList](#friendlist)
   - [`C_FriendList.SendWhoQueryByName(name)`](#c_friendlistsendwhoquerybynamename)
@@ -3779,6 +3780,97 @@ UIParent:GetEffectiveAlpha()   -- 1
 -- with UIParent at 0.5 and Minimap's own alpha 1:
 Minimap:GetEffectiveAlpha()    -- ~0.498 (0.5 truncates to 127/255)
 ```
+
+### `frame:SetAttribute(name, value)` / `frame:SetAttributeNoHandler(name, value)` / `frame:GetAttribute(...)`
+
+Backports the frame **attribute** system — a per-frame, case-insensitive
+key→value store — to 1.12 as native methods on every frame. Attributes were
+added in 2.0 with secure frames and don't exist in vanilla at all; `value`
+can be any Lua type and round-trips exactly.
+
+```lua
+f:SetAttribute("unit", "party1")
+f:GetAttribute("unit")            -- "party1"
+f:SetAttribute("count", 3)
+f:GetAttribute("count")           -- 3
+f:GetAttribute("missing")         -- nil
+```
+
+`GetAttribute` also has the modifier form `GetAttribute(prefix, name, suffix)`,
+which tries, in order, and returns the first match (the same precedence retail
+uses for `type1`/`*type1`-style resolution):
+
+1. `prefix..name..suffix`
+2. `"*"..name..suffix`
+3. `prefix..name.."*"`
+4. `"*"..name.."*"`
+5. `name`
+
+`SetAttributeNoHandler` is an alias of `SetAttribute` here — see the
+`OnAttributeChanged` note below.
+
+**Unit-frame mouseover — the headline use.** Setting a **string `unit`
+attribute** makes the frame a mouseover source: while the cursor is over it,
+the `mouseover` unit token resolves to that frame's unit. This is the piece of
+SecureUnitButton behavior modern unit-frame addons rely on — and since 1.12 has
+no combat lockdown or taint, no secure machinery is needed to provide it.
+
+```lua
+local f = CreateFrame("Button", "MyUnitFrame", UIParent)
+f:SetWidth(120); f:SetHeight(40)
+f:SetPoint("CENTER")
+f:SetAttribute("unit", "party1")
+-- Hover it → the `mouseover` token resolves to party1:
+--   UnitName("mouseover"), UnitHealth("mouseover"), GameTooltip:SetUnit("mouseover"),
+--   mouseover-cast, and UPDATE_MOUSEOVER_UNIT all work.
+```
+
+How it works, and why it's robust: rather than installing `OnEnter`/`OnLeave`
+on the frame (which an addon's own `SetScript("OnEnter", …)` would overwrite —
+pfUI sets `unit` *before* its scripts, for instance), this mirrors retail and
+SuperWoW's `SetMouseoverUnit`. The engine's mouse-focus frame is watched once
+per frame; when a hovered frame carries a `unit` attribute, the engine's **real
+mouseover setter** is invoked for that unit — **1:1 with hovering the unit's 3D
+model**: the model highlights, the mouseover tooltip builds, and
+`UPDATE_MOUSEOVER_UNIT` fires, in addition to the GUID slot being set. So
+everything that reads mouseover — the resolver's `mouseover` branch,
+`GameTooltip:SetUnit("mouseover")`, `UnitX("mouseover")`, mouseover-cast — sees
+it natively. Because nothing touches the frame's scripts, an addon setting its
+own handlers can't break it; and it's stomp-proof (the engine's 3D-hover setter
+is event-driven, so while the cursor is over UI nothing overwrites the slot). It
+follows live token changes (a `unit="target"` frame tracks your current target
+while hovered). Setting a string `unit` also `EnableMouse`s the frame so a bare
+frame becomes hoverable at all (real unit frames already are). The `unit` value
+may be any token the resolver understands — `"party1"`, `"target"`, `"focus"`,
+`"nameplateN"`, or a raw GUID literal. Set `unit` to a non-string (e.g. `nil`)
+to stop the binding.
+
+**Click actions (`type1` / `type2`).** A `type` attribute makes clicking the
+frame act on its `unit`:
+
+```lua
+f:SetAttribute("type1", "target")   -- left-click targets the unit
+f:SetAttribute("type2", "focus")    -- right-click sets ClassicAPI focus to it
+```
+
+Left-click reads `type1`, right-click reads `type2`, and both fall back to a
+plain `type` attribute. Supported verbs: `"target"`, `"assist"` (target the
+unit's target), `"focus"`. Setting a `type*` attribute installs a **chained
+`OnClick` on that frame only** (nothing global) — it reads the attributes at
+click time and runs *after* any handler the frame already had. Because it chains
+whatever `OnClick` is present when the `type` attribute is set, set `type*`
+**after** the frame's own scripts (real addons configure attributes after
+building the widget). The frame must be a **Button** registered for the click:
+left is the Button default; right needs `RegisterForClicks("RightButtonUp")`,
+which real unit frames already call. Other verbs (`togglemenu`, `spell`,
+`macro`) aren't backported yet.
+
+**`OnAttributeChanged` is not fired.** Retail fires this script from
+`SetAttribute` (and `SetAttributeNoHandler` suppresses it). Making it a real
+`SetScript`-able handler needs a co-hook on the base-frame script-name resolver
+(the analog of the tooltip-side `OnTooltipSet*` work); it isn't required for the
+mouseover use case, so `SetAttribute` currently doesn't fire it and the two
+setters behave identically. Fast-follow.
 
 ## FriendList
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -3875,7 +3875,7 @@ modifier/button-qualified, same precedence as `type`):
 
 | Verb | Extra attributes | Action |
 |------|------------------|--------|
-| `target` | — | Targets the `unit`. Respects the engine's default-interaction precedence: with a spell on the cursor it casts on the unit, with an item on the cursor it drops it on the unit, instead of switching target. |
+| `target` | — | Targets the `unit` (or clears the target if `unit` is `"none"`). Respects the engine's default-interaction precedence: with a spell on the cursor it casts on the unit, with an item on the cursor it drops it on the unit, instead of switching target. |
 | `assist` | — | Targets the `unit`'s target. |
 | `focus` | — | Sets the ClassicAPI focus to the `unit`. |
 | `spell` | `spell` | Casts the `spell` on the `unit` via [`C_Spell.CastAtUnit`](#c_spellcastatunitspellidorname-unit) — the unit's GUID goes straight to the cast dispatcher (no target juggling), and ground-target spells land at the unit's feet. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -3870,23 +3870,22 @@ the button number (`1`=Left, `2`=Right, `3`=Middle, `4`/`5`=side). Precedence is
 modifier unless a modifier-specific attribute (`shift-type1`) overrides it — and
 `type` (no suffix) is the catch-all.
 
-**Verbs:** `target`, `assist`, `focus`, `spell` (reads the modifier-qualified
-`spell` attribute and casts it on the unit via the native
-[`C_Spell.CastAtUnit`](#c_spellcastatunitspellidorname-unit) — the unit's GUID is fed straight to
-the cast dispatcher, so there's no target juggling, and ground-target spells
-land at the unit's feet), `item` (uses the `item` attribute — an item
-name/itemID/link via `C_Item.UseItemByName` with the unit as the use target, or
-a `"bag slot"` string like `"0 1"` via `UseContainerItem`; the deprecated
-`bag`/`slot` attributes also work), `macro` (takes the
-`macrotext`/`macro` attribute and prefers an addon-provided `RunMacro` — e.g.
-SuperCleveRoidMacros, which handles named macros and extended macro text —
-falling back to running the text natively, line by line through the stock
-`ChatEdit_ParseText`, when no `RunMacro` global is present), `stopcasting`, and `menu` /
-`togglemenu` (pops the standard unit dropdown — whisper/inspect/trade/invite/…,
-the same menu `PlayerFrame`/`TargetFrame`/`PartyMemberFrame` show — at the
-cursor). `target` respects the engine's default-interaction precedence: with a
-spell on the cursor it casts on the unit, with an item on the cursor it drops it
-on the unit, instead of switching target.
+**Verbs.** The resolved verb reads its own extra attributes (also
+modifier/button-qualified, same precedence as `type`):
+
+| Verb | Extra attributes | Action |
+|------|------------------|--------|
+| `target` | — | Targets the `unit`. Respects the engine's default-interaction precedence: with a spell on the cursor it casts on the unit, with an item on the cursor it drops it on the unit, instead of switching target. |
+| `assist` | — | Targets the `unit`'s target. |
+| `focus` | — | Sets the ClassicAPI focus to the `unit`. |
+| `spell` | `spell` | Casts the `spell` on the `unit` via [`C_Spell.CastAtUnit`](#c_spellcastatunitspellidorname-unit) — the unit's GUID goes straight to the cast dispatcher (no target juggling), and ground-target spells land at the unit's feet. |
+| `item` | `item`, or `bag`+`slot` | Uses an item on the `unit`. `item` may be a name / itemID / link (used via `C_Item.UseItemByName`, unit as the target) or a `"bag slot"` string like `"0 1"` (used via `UseContainerItem`). The deprecated `bag`+`slot` attributes are used when `item` is unset. |
+| `macro` | `macrotext` or `macro` | Runs the macro text. Prefers an addon `RunMacro` (e.g. SuperCleveRoidMacros — named macros + extended conditionals); otherwise runs the text natively, line by line, through the stock `ChatEdit_ParseText`. |
+| `stopcasting` | — | Stops the current cast. |
+| `menu` / `togglemenu` | — | Pops the standard unit dropdown at the cursor (whisper / inspect / trade / invite / …, the same menu `PlayerFrame` / `TargetFrame` / `PartyMemberFrame` show). |
+
+Every verb that acts on a unit uses the frame's `unit` attribute (resolved with
+the same modifier/button precedence).
 
 **One verb per click.** Setting a `type*` attribute installs a **chained
 `OnClick` on that frame only** (nothing global). When a verb resolves, our

--- a/docs/API.md
+++ b/docs/API.md
@@ -164,7 +164,7 @@ build instructions.
   - [`frame:HookScript(scriptType, handler)`](#framehookscriptscripttype-handler)
   - [`frame:IsEventRegistered(event)`](#frameiseventregisteredevent)
   - [`frame:GetEffectiveAlpha()`](#framegeteffectivealpha)
-  - [`frame:SetAttribute` / `SetAttributeNoHandler` / `GetAttribute` (+ unit-frame mouseover)](#framesetattributename-value--framesetattributenohandlername-value--framegetattribute)
+  - [`frame:SetAttribute` / `SetAttributeNoHandler` / `ClearAttribute` / `GetAttribute` (+ unit-frame mouseover)](#framesetattributename-value--framesetattributenohandlername-value--frameclearattributename--framegetattribute)
 
 - [FriendList](#friendlist)
   - [`C_FriendList.SendWhoQueryByName(name)`](#c_friendlistsendwhoquerybynamename)
@@ -3781,16 +3781,22 @@ UIParent:GetEffectiveAlpha()   -- 1
 Minimap:GetEffectiveAlpha()    -- ~0.498 (0.5 truncates to 127/255)
 ```
 
-### `frame:SetAttribute(name, value)` / `frame:SetAttributeNoHandler(name, value)` / `frame:GetAttribute(...)`
+### `frame:SetAttribute(name, value)` / `frame:SetAttributeNoHandler(name, value)` / `frame:ClearAttribute(name)` / `frame:GetAttribute(...)`
 
 Backports the frame **attribute** system — a per-frame, case-insensitive
 key→value store — to 1.12 as native methods on every frame. Attributes were
 added in 2.0 with secure frames and don't exist in vanilla at all; `value`
 can be any Lua type and round-trips exactly.
 
+`cleared = frame:ClearAttribute(name)` (retail 11.2.0) removes an attribute and
+returns whether it was set. Unlike `SetAttribute`, it does **not** fire
+`OnAttributeChanged` — matching retail (verified against a live 12.0 client).
+
 ```lua
 f:SetAttribute("unit", "party1")
 f:GetAttribute("unit")            -- "party1"
+f:ClearAttribute("unit")          -- true  (was set; now removed)
+f:ClearAttribute("unit")          -- false (nothing to clear)
 f:SetAttribute("count", 3)
 f:GetAttribute("count")           -- 3
 f:GetAttribute("missing")         -- nil

--- a/docs/API.md
+++ b/docs/API.md
@@ -3806,8 +3806,8 @@ uses for `type1`/`*type1`-style resolution):
 4. `"*"..name.."*"`
 5. `name`
 
-`SetAttributeNoHandler` is an alias of `SetAttribute` here — see the
-`OnAttributeChanged` note below.
+`SetAttributeNoHandler` sets the value **without** firing `OnAttributeChanged`;
+`SetAttribute` fires it (see below).
 
 **Unit-frame mouseover — the headline use.** Setting a **string `unit`
 attribute** makes the frame a mouseover source: while the cursor is over it,
@@ -3845,32 +3845,75 @@ may be any token the resolver understands — `"party1"`, `"target"`, `"focus"`,
 `"nameplateN"`, or a raw GUID literal. Set `unit` to a non-string (e.g. `nil`)
 to stop the binding.
 
-**Click actions (`type1` / `type2`).** A `type` attribute makes clicking the
-frame act on its `unit`:
+**Click actions (`type1` / `type2` / …).** A `type` attribute makes clicking the
+frame perform one action on its `unit` — the retail secure-button model: exactly
+**one verb per click**, resolved from the attributes.
 
 ```lua
-f:SetAttribute("type1", "target")   -- left-click targets the unit
-f:SetAttribute("type2", "focus")    -- right-click sets ClassicAPI focus to it
+f:SetAttribute("type1", "target")        -- left-click targets the unit
+f:SetAttribute("type2", "focus")         -- right-click sets ClassicAPI focus to it
+-- click-casting, expressed purely as attributes:
+f:SetAttribute("shift-type1", "spell")
+f:SetAttribute("shift-spell1", "Flash Heal")   -- shift-left-click heals the unit
 ```
 
-Left-click reads `type1`, right-click reads `type2`, and both fall back to a
-plain `type` attribute. Supported verbs: `"target"`, `"assist"` (target the
-unit's target), `"focus"`. Setting a `type*` attribute installs a **chained
-`OnClick` on that frame only** (nothing global) — it reads the attributes at
-click time and runs *after* any handler the frame already had. Because it chains
-whatever `OnClick` is present when the `type` attribute is set, set `type*`
-**after** the frame's own scripts (real addons configure attributes after
-building the widget). The frame must be a **Button** registered for the click:
-left is the Button default; right needs `RegisterForClicks("RightButtonUp")`,
-which real unit frames already call. Other verbs (`togglemenu`, `spell`,
-`macro`) aren't backported yet.
+**Resolution.** The verb is read from `[prefix]type[suffix]`, where the prefix is
+the held modifiers (`alt-`, `ctrl-`, `shift-`, in that order) and the suffix is
+the button number (`1`=Left, `2`=Right, `3`=Middle, `4`/`5`=side). Precedence is
+`prefix..type..suffix` → `type..suffix` → `type`, so `type1` applies under any
+modifier unless a modifier-specific attribute (`shift-type1`) overrides it — and
+`type` (no suffix) is the catch-all.
 
-**`OnAttributeChanged` is not fired.** Retail fires this script from
-`SetAttribute` (and `SetAttributeNoHandler` suppresses it). Making it a real
-`SetScript`-able handler needs a co-hook on the base-frame script-name resolver
-(the analog of the tooltip-side `OnTooltipSet*` work); it isn't required for the
-mouseover use case, so `SetAttribute` currently doesn't fire it and the two
-setters behave identically. Fast-follow.
+**Verbs:** `target`, `assist`, `focus`, `spell` (reads the modifier-qualified
+`spell` attribute and casts it on the unit via the native
+[`C_Spell.CastAtUnit`](#c_spellcastatunitspellidorname-unit) — the unit's GUID is fed straight to
+the cast dispatcher, so there's no target juggling, and ground-target spells
+land at the unit's feet), `macro` (takes the
+`macrotext`/`macro` attribute and prefers an addon-provided `RunMacro` — e.g.
+SuperCleveRoidMacros, which handles named macros and extended macro text —
+falling back to running the text natively, line by line through the stock
+`ChatEdit_ParseText`, when no `RunMacro` global is present), `stopcasting`, and `menu` /
+`togglemenu` (pops the standard unit dropdown — whisper/inspect/trade/invite/…,
+the same menu `PlayerFrame`/`TargetFrame`/`PartyMemberFrame` show — at the
+cursor). `target` respects the engine's default-interaction precedence: with a
+spell on the cursor it casts on the unit, with an item on the cursor it drops it
+on the unit, instead of switching target.
+
+**One verb per click.** Setting a `type*` attribute installs a **chained
+`OnClick` on that frame only** (nothing global). When a verb resolves, our
+handler *owns* the click and does **not** run the frame's previous `OnClick` —
+so a configured `type1` never fires alongside the addon's own click handler.
+Unconfigured clicks (no matching `type`, or an unrecognized verb) fall through
+to the frame's own `OnClick`, so an addon can keep custom behavior there. The
+frame must be a **Button** registered for the click
+(left is the Button default; right needs `RegisterForClicks("RightButtonUp")`).
+
+**Clobbering.** The handler self-heals: addons that re-`SetScript("OnClick", …)`
+(pfUI on every raid relayout) replace our closure, so re-set a `type*` attribute
+afterward to reinstall — re-wiring detects and skips its own closure, so it never
+double-chains.
+
+**`OnAttributeChanged`** is a real `SetScript` / `GetScript` / `HookScript`-able
+frame script, on **every** frame — `SetAttribute` fires it after setting the
+value, `SetAttributeNoHandler` doesn't. As with all 1.12 frame scripts, the
+handler takes no parameters and reads its context from globals: `this` = the
+frame, `arg1` = the (lowercased) attribute name, `arg2` = the new value.
+
+```lua
+f:SetScript("OnAttributeChanged", function()
+    if arg1 == "unit" then
+        MyFrame_Update(this, arg2)   -- react to unit changes
+    end
+end)
+f:SetAttribute("unit", "party1")     -- fires the handler (arg1="unit", arg2="party1")
+f:SetAttributeNoHandler("unit", "party2")  -- sets it silently, no handler
+```
+
+It's implemented the same way as the tooltip-side `OnTooltipSet*` scripts — a
+co-hook on the base-frame script-name resolver that hands out an external
+per-frame handler slot for this one name (1.12 frames are never destroyed, so
+the slot never goes stale). Recursion-guarded, so a handler may itself call
+`SetAttribute`.
 
 ## FriendList
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -185,6 +185,33 @@ void SetGlobalNumber(void *L, const char *name, double value) {
     RawSet(L, GLOBALS_INDEX);
 }
 
+bool PushGlobalFunction(void *L, const char *name) {
+    PushString(L, name);
+    GetTable(L, GLOBALS_INDEX);
+    if (Type(L, -1) == TYPE_FUNCTION)
+        return true;
+    SetTop(L, -2); // pop the non-function
+    return false;
+}
+
+void CallGlobal(void *L, const char *name) {
+    const int top = GetTop(L);
+    if (PushGlobalFunction(L, name))
+        Call(L, 0, 0);
+    SetTop(L, top);
+}
+
+bool CallGlobalString(void *L, const char *name, const char *arg) {
+    const int top = GetTop(L);
+    const bool called = PushGlobalFunction(L, name);
+    if (called) {
+        PushString(L, arg);
+        Call(L, 1, 0);
+    }
+    SetTop(L, top);
+    return called;
+}
+
 void PushLocalizedString(void *L, const char *globalName, const char *fallback) {
     PushString(L, globalName);
     GetTable(L, GLOBALS_INDEX);

--- a/src/Game.h
+++ b/src/Game.h
@@ -244,6 +244,22 @@ void PushLocalizedString(void *L, const char *globalName, const char *fallback);
 // using `PushLocalizedString` + manual `string.format` invocation.
 void PushLocalizedFormatInt(void *L, const char *globalName,
                             const char *fallback, int n);
+
+// Pushes `_G[name]` and returns true only if it resolved to a function
+// (leaving it on the stack, ready to be called); otherwise pops it and
+// returns false. The building block for the CallGlobal* helpers below and for
+// any C module that dispatches to a Lua/FrameXML global by name (a pattern
+// several modules otherwise open-code).
+bool PushGlobalFunction(void *L, const char *name);
+
+// `_G[name]()` — no args, no results; a no-op if the global isn't a function.
+// Stack-neutral.
+void CallGlobal(void *L, const char *name);
+
+// `_G[name](arg)` — one string arg (NULL → nil), no results. Returns true iff
+// the global was a function and got called, so callers can fall back to a
+// native path when the FrameXML/addon global is absent. Stack-neutral.
+bool CallGlobalString(void *L, const char *name, const char *arg);
 } // namespace Lua
 
 // Developer-console command system — the `~` console available when the

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -140,6 +140,18 @@ enum Offsets {
     //   and call the inner invoker, which is self-contained.
     FUN_GAMETOOLTIP_SCRIPT_RESOLVER = 0x005295D0,
     FUN_FRAME_INVOKE_SCRIPT = 0x00704D50,
+    // The base Frame script-name resolver — __thiscall(frame, const char *name)
+    // -> int* slot, 0 for an unknown name. Maps the standard base-frame scripts
+    // to their 8-byte {handler, context} slots on the frame (OnLoad@+0x118,
+    // OnUpdate@+0x128, OnEnter@+0x140, … OnKeyUp@+0x190) after delegating to the
+    // ScriptObject base FUN_00702590 (OnEvent@+0xC). Every frame TYPE's resolver
+    // chains through this (the tooltip resolver above calls it first), so
+    // co-hooking it here lets `Frame::Attributes` make `OnAttributeChanged`
+    // SetScript/GetScript/HookScript-able on ALL frames — for that one name the
+    // co-hook hands back an external per-frame cell (frames are immortal in 1.12,
+    // so a pointer-keyed cell never goes stale). Same pattern + ABI modeling as
+    // FUN_GAMETOOLTIP_SCRIPT_RESOLVER.
+    FUN_FRAME_SCRIPT_RESOLVER = 0x0076A0D0,
     // The other per-object tooltip builders, co-hooked the same way as
     // FUN_GAMETOOLTIP_BUILD_ITEM to back OnTooltipSetSpell / OnTooltipSetUnit /
     // OnTooltipSetGameObject (see Tooltip::SetEvents). Each is the single funnel

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -1376,8 +1376,28 @@ enum Offsets {
     // funnels through here (the raw-ingress sibling at 0x00537B10 only
     // special-cases 0x1DD compressed-moves before queueing into this).
     // Useful as a temporary whole-protocol sniff point: co-hook, peek the
-    // u16 at the cursor, restore, log.
+    // u16 at the cursor, restore, log. `Net::PacketDispatch` co-hooks it as
+    // the single fan-out point for incoming-packet subscribers — the
+    // collision-avoiding alternative to each feature MinHook-ing its
+    // per-opcode SMSG handler (which nampower/SuperWoW also hook). nampower
+    // does NOT hook this funnel (it detours the per-opcode handlers), so
+    // moving our parsing here removes those shared prologues.
     FUN_NET_MESSAGE_DISPATCH = 0x00537AA0,
+
+    // Incoming spell-subsystem SMSG opcodes — the u16 message ids the engine
+    // dispatch table (see FUN_006e7150) maps to per-opcode handlers. Used by
+    // the `Net::PacketDispatch` subscribers that replaced the per-handler
+    // co-hooks. Verified from the registrar: 0x131/0x132 both route to
+    // FUN_006E7640 (it branches on the opcode; the 0x132 path decodes and
+    // calls the SpellGo builder FUN_006E7A70).
+    SMSG_SPELL_START = 0x131,
+    SMSG_SPELL_GO = 0x132,
+    SMSG_SPELL_FAILURE = 0x133,
+    SMSG_SPELL_COOLDOWN = 0x134,
+    SMSG_SPELL_CHANNEL_START = 0x139,
+    SMSG_SPELL_CHANNEL_UPDATE = 0x13A,
+    SMSG_SPELL_DELAYED = 0x1E2,
+    SMSG_SPELL_FAILED_OTHER = 0x2A6,
 
     // NetClient send — `__thiscall void(void *conn, CDataStore *packet)`.
     // The outgoing counterpart of FUN_NET_MESSAGE_DISPATCH: every CMSG the

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -140,6 +140,39 @@ enum Offsets {
     //   and call the inner invoker, which is self-contained.
     FUN_GAMETOOLTIP_SCRIPT_RESOLVER = 0x005295D0,
     FUN_FRAME_INVOKE_SCRIPT = 0x00704D50,
+    // The arg-passing sibling of FUN_FRAME_INVOKE_SCRIPT — every frame
+    // script that carries values (OnClick(button), OnMouseWheel(delta),
+    // OnUpdate(elapsed), OnValueChanged(value), OnKeyDown(key), OnEvent's
+    // args, …) funnels through here. __cdecl(int handlerRef, void *frame,
+    // const char *fmt, void *vaPtr): fmt is a printf-style spec string
+    // (`%d`/`%u`/`%f`/`%s`), vaPtr points at the packed vararg buffer
+    // (4-byte stride for d/u/s, 8 for f). It sets the `arg1..argN` globals
+    // from the format (saving/restoring the previous values), sets the
+    // `this` global to `frame`, then runs the handler under a protected
+    // lua_pcall with **zero Lua args** and the engine error handler
+    // (VAR_FRAMESCRIPT_ERROR_HANDLER_REF) as errfunc. FUN_FRAME_INVOKE_SCRIPT
+    // is the same shape for the no-arg scripts (OnShow/OnHide/OnEnter/…).
+    // `Frame::ScriptArgs` co-hooks both to additionally pass the handler
+    // modern positional args (self, arg1..argN). The frame's own Lua object
+    // ref lives at frame+OFF_COBJECT_LUA_REF (refcount at
+    // OFF_COBJECT_LUA_REFCOUNT); FUN_FRAMESCRIPT_OBJECT_SCRIPT_REGISTER
+    // lazily creates it when the refcount is 0.
+    FUN_FRAME_RUN_SCRIPT_ARGS = 0x00704F10,
+    // The base ScriptObject's OnEvent handler slot — an 8-byte
+    // {handler, context} pair at frame+0x0C (from FUN_00702590, the base
+    // resolver every frame-type resolver chains through, and confirmed by
+    // the event dispatchers FUN_00703E50 / FUN_00703F50 passing `frame+0xC`
+    // as the slot). `*(int*)(frame + OFF_FRAME_ONEVENT_SLOT)` is the OnEvent
+    // handler ref; `Frame::ScriptArgs` compares it against the handler ref
+    // the runner is invoking to detect an OnEvent dispatch (exact — each
+    // SetScript makes a distinct ref, so a function bound to two scripts
+    // still differs per slot) and prepend the `event` positional.
+    OFF_FRAME_ONEVENT_SLOT = 0x0C,
+    // Registry ref (an int, not a pointer) to the frame-script message
+    // handler the engine passes as the `errfunc` to every script pcall —
+    // read as `*(int*)VAR_FRAMESCRIPT_ERROR_HANDLER_REF`, pushed via
+    // lua_rawgeti(REGISTRY, ref). Set once at engine init.
+    VAR_FRAMESCRIPT_ERROR_HANDLER_REF = 0x008722C8,
     // The base Frame script-name resolver — __thiscall(frame, const char *name)
     // -> int* slot, 0 for an unknown name. Maps the standard base-frame scripts
     // to their 8-byte {handler, context} slots on the frame (OnLoad@+0x118,
@@ -422,6 +455,12 @@ enum Offsets {
     // read it as a "has the engine ever exposed this CObject to Lua"
     // probe — equivalent to checking `this+0x08 > 0` but more direct.
     OFF_COBJECT_LUA_REFCOUNT = 0x04,
+
+    // `this+0x08` — the CObject's Lua-registry ref (an int key into the
+    // registry table). `lua_rawgeti(REGISTRY, this[+0x08])` pushes the
+    // frame's Lua-side object. Lazily populated by ScriptRegister when the
+    // refcount above is 0.
+    OFF_COBJECT_LUA_REF = 0x08,
 
     // Direct cvar lookup — `__fastcall(const char *name) → CVar* | NULL`.
     // Hash-table by-name lookup over the CVar registry; same call
@@ -4092,6 +4131,15 @@ enum Offsets {
     LUA_NEW_TABLE = 0x6F3C90,
     LUA_GET_TABLE = 0x6F3A40,     // (was 0x6F3EA0, which is lua_rawset)
     LUA_RAW_GET = 0x6F3B00,
+    // `lua_rawgeti(L, idx, n)` — pushes `table_at_idx[n]` without invoking
+    // metamethods. __fastcall(L /*ecx*/, idx /*edx*/, n /*stack*/). The
+    // frame-script runner uses it with `idx = REGISTRY` to push a value
+    // stored under an integer ref (handler, frame object, message handler,
+    // and luaL_ref'd saved globals). Note it also carries the WoW
+    // frame-script exec-context stamp (the `DAT_00ceeac0` dance) for pushed
+    // CObjects — which is exactly why the engine pushes handler/frame
+    // through it rather than a plain rawget.
+    LUA_RAWGETI = 0x6F3BC0,
     LUA_SET_TABLE = 0x6F3E20,
     LUA_RAW_SET = 0x6F3EA0,
     LUA_INSERT = 0x6F31A0,

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -1422,12 +1422,27 @@ enum Offsets {
     // clear on `*(context+0xCFC) == self`, i.e. the IsDragging predicate.
     VAR_UI_CONTEXT_PTR = 0x00CF0BD8,
     OFF_UI_CONTEXT_DRAG_TARGET = 0xCFC,
+    // Frame currently under the mouse (the CFrameScriptObject* that
+    // `GetMouseFocus` returns): `*(*VAR_UI_CONTEXT_PTR + 0x7C)`. 0 when the
+    // cursor is over no mouse-enabled frame. `Frame::Attributes` polls this to
+    // drive the `mouseover` override from the hovered frame's `unit` attribute.
+    OFF_UI_CONTEXT_MOUSE_FOCUS = 0x7C,
     FUN_SCRIPT_FRAME_SHOW = 0x00775750,
     FUN_SCRIPT_FRAME_HIDE = 0x00775810,
     FUN_SCRIPT_FRAME_SETMINRESIZE = 0x00776020,
     FUN_SCRIPT_FRAME_SETMAXRESIZE = 0x007762A0,
     FUN_SCRIPT_FRAME_GETSCRIPT = 0x00774780,
     FUN_SCRIPT_FRAME_SETSCRIPT = 0x007748D0,
+    // `frame:EnableMouse(enable)` (Frame registry) — `Frame::Attributes` calls
+    // it so a unit-attributed frame registers as the mouse-focus (bare frames
+    // otherwise never hover). Standard `int __fastcall(void *L)` Script_* shape.
+    FUN_SCRIPT_FRAME_ENABLEMOUSE = 0x00777070,
+    // Button OnClick dispatcher — `__thiscall(button, buttonCode)` at
+    // 0x00779540, invoking the button's OnClick slot `[button+0x4CC]`. NOTE: do
+    // NOT MinHook it — SuperWoW's click-casting inline-hooks the same prologue
+    // and a second hook corrupts the trampoline (ERROR #132). `Frame::Attributes`
+    // instead installs a normal chained OnClick on the opted-in frame. Kept as
+    // the verified dispatch reference only.
     // Frame GetAlpha (own alpha, 0..1) + Region GetParent — walked by
     // Frame::Modern's GetEffectiveAlpha up the parent chain.
     FUN_SCRIPT_FRAME_GETALPHA = 0x00774DC0,

--- a/src/aura/Source.cpp
+++ b/src/aura/Source.cpp
@@ -19,6 +19,7 @@
 #include "Data.h"
 #include "Game.h"
 #include "Offsets.h"
+#include "net/PacketDispatch.h"
 #include "net/PacketReader.h"
 #include "player/StatSignal.h"
 #include "spell/CastEvents.h"
@@ -555,30 +556,15 @@ const Tick::WorldTick::AutoSubscribe _tickSub{&OnWorldTick};
 // keeps the parse short and robust.
 constexpr int kMaxTargets = 16;
 
-using SpellGo_t = void(__fastcall *)(uint64_t *itemGUID, uint64_t *casterGUID,
-                                     uint32_t spellId, CDataStore *packet);
-SpellGo_t g_origSpellGo = nullptr;
-
-void __fastcall SpellGo_h(uint64_t *itemGUID, uint64_t *casterGUID,
-                          uint32_t spellId, CDataStore *packet) {
-    uint64_t targets[kMaxTargets];
-    int numTargets = 0;
-
-    if (packet != nullptr) {
-        const uint32_t savedRead = packet->m_read;
-        Net::Read<int16_t>(packet); // castFlags (unused)
-        const uint8_t numHit = Net::Read<uint8_t>(packet);
-        for (int i = 0; i < numHit; ++i) {
-            const uint64_t guid = Net::Read<uint64_t>(packet);
-            if (numTargets < kMaxTargets)
-                targets[numTargets++] = guid;
-        }
-        packet->m_read = savedRead; // restore so the engine re-parses cleanly
-    }
-
-    g_origSpellGo(itemGUID, casterGUID, spellId, packet);
-
-    const uint64_t caster = (casterGUID != nullptr) ? *casterGUID : 0;
+// The self-contained SPELL_GO processing (succeeded events, server-side
+// duration edits, aura-source caching). None of it reads engine descriptor
+// state, so it's order-independent of the engine's own SPELL_GO handler —
+// which is why it can run from the dispatch funnel (before the leaf handler)
+// rather than after a co-hook's original call. The aura *application* hooks
+// fire off a separate SMSG_UPDATE_OBJECT, so RememberPlayerCast's handoff to
+// them is unaffected by the move.
+void HandleSpellGo(uint64_t caster, uint32_t spellId, const uint64_t *targets,
+                   int numTargets) {
     if (caster == 0 || spellId == 0)
         return;
 
@@ -631,9 +617,33 @@ void __fastcall SpellGo_h(uint64_t *itemGUID, uint64_t *casterGUID,
               KIND_UNKNOWN);
 }
 
-const Game::HookAutoRegister _hook{Offsets::FUN_SPELL_GO,
-                                   reinterpret_cast<void *>(&SpellGo_h),
-                                   reinterpret_cast<void **>(&g_origSpellGo)};
+// SMSG_SPELL_GO parse (funnel subscriber). At the leaf handler the engine has
+// pre-decoded itemGuid/casterGuid/spellId; here we're at the raw body, so we
+// decode them ourselves before the hit list:
+//   itemGuid(packed), casterGuid(packed), spellId(u32), castFlags(i16),
+//   numHit(u8), hitGuids(u64 × numHit).
+void ParseSpellGo(CDataStore *packet) {
+    Net::ReadPackedGuid(packet); // itemGuid (unused)
+    const uint64_t caster = Net::ReadPackedGuid(packet);
+    const uint32_t spellId = Net::Read<uint32_t>(packet);
+    Net::Read<int16_t>(packet); // castFlags (unused)
+    const uint8_t numHit = Net::Read<uint8_t>(packet);
+    uint64_t targets[kMaxTargets];
+    int numTargets = 0;
+    for (int i = 0; i < numHit; ++i) {
+        const uint64_t guid = Net::Read<uint64_t>(packet);
+        if (numTargets < kMaxTargets)
+            targets[numTargets++] = guid;
+    }
+    HandleSpellGo(caster, spellId, targets, numTargets);
+}
+
+void SpellGoSub(uint32_t opcode, CDataStore *packet) {
+    if (opcode == Offsets::SMSG_SPELL_GO && packet != nullptr)
+        ParseSpellGo(packet);
+}
+
+const Net::PacketDispatch::AutoSubscribe _spellGoSub{&SpellGoSub};
 
 // ---- Aura-application co-hooks (timing for proc / triggered auras) -------
 

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -46,23 +46,55 @@
 //
 // Clicks are events, not state, so they belong on the frame's OnClick — but
 // ONLY on frames that opt in with a `type` attribute. When a `type*` attribute
-// is first set we install a chained OnClick on that frame (protected, because
-// OnClick is Button-only); it reads `unit` + `type1`/`type2`/`type` at click
-// time and performs the action, then runs any previously-set handler. Verbs:
-// `target`, `assist` (target the unit's target), `focus`. No global hook, no
-// per-frame handler on frames that never asked for one.
+// is set we install a chained OnClick on that frame (protected, because OnClick
+// is Button-only). It mirrors retail's SecureActionButton_OnClick: resolve ONE
+// verb per click from the modifier/button-qualified `type` attribute, perform
+// it, done. No global hook, no handler on frames that never asked for one.
 //
-// Ordering: because it chains the handler present when `type*` is set, set the
-// `type` attribute AFTER the frame's own `OnClick` (real addons configure
-// attributes after building the widget). The frame must be a Button registered
-// for the relevant clicks (`RegisterForClicks`) — left is the Button default;
-// right needs `RegisterForClicks("RightButtonUp")`, which real unit frames do.
+// Resolution (retail-style): the attribute is `[prefix]type[suffix]`, where the
+// prefix is the held modifiers ("alt-"/"ctrl-"/"shift-") and the suffix is the
+// button number (1=Left, 2=Right, …). So `type1`, `shift-type1`, `type` all
+// resolve via ReadModAttr's precedence. Verbs: `target` (with the engine's
+// default-interaction precedence — pending spell / cursor item cast/drop on the
+// unit instead of switching target), `assist`, `focus`, `spell` (reads the
+// `spell` attribute and casts it on the unit via our native C_Spell.CastAtUnit —
+// the unit's GUID goes straight to the cast dispatcher, no target juggling, and
+// ground-target spells land at the unit's feet), `macro` (from the
+// `macrotext`/`macro` attribute — prefers an addon RunMacro, else runs natively
+// via the stock ChatEdit_ParseText), `stopcasting`, `menu`/`togglemenu` (pops
+// the standard unit dropdown at the cursor via the addon's
+// ClassicAPI_ToggleUnitMenu). Actions call ordinary Lua globals where the entry
+// is the engine's (TargetUnit, IsAltKeyDown, …); where we own a C++ module the
+// dispatch goes straight to it, no Lua round-trip (Spell::AtUnit for `spell`,
+// Unit::Focus for `focus`). All run under the engine's protected OnClick.
 //
-// NOT DONE: `OnAttributeChanged` as a real SetScript-able handler — needs a
-// base-frame script-name resolver co-hook (the `Tooltip::SetEvents` analog).
+// One verb per click is the point: because we own the click when a verb
+// resolves (and only then chain the previous handler), a configured `type1` no
+// longer runs *alongside* the addon's own conditional OnClick — that double
+// dispatch (our fixed "target" + pfUI's ClickAction) was the conflict. An addon
+// expresses all its click behavior as attributes; unconfigured clicks fall
+// through to its OnClick (e.g. a right-click menu).
+//
+// Ordering / clobbering: it chains the handler present when `type*` is set, so
+// set `type*` AFTER the frame's own `OnClick`. Addons that re-`SetScript`
+// `OnClick` later (pfUI does on every raid relayout) replace our closure — so
+// re-set `type*` after re-SetScript to recover. Re-wiring is safe: WireOnClick
+// re-wraps a clobbered (Lua) handler but skips its own C closure, so it never
+// double-chains. The frame must be a Button registered for the relevant clicks
+// (`RegisterForClicks`) — left is the Button default; right needs
+// `RegisterForClicks("RightButtonUp")`, which real unit frames do.
+//
+// `OnAttributeChanged` is a real SetScript-able handler: SetAttribute (not
+// SetAttributeNoHandler) fires it with `this` = frame, `arg1` = name, `arg2` =
+// value. Implemented by co-hooking the base-frame script-name resolver
+// (`FUN_FRAME_SCRIPT_RESOLVER`) and handing out an external per-frame cell for
+// that name — the `Tooltip::SetEvents` analog, applied to every frame.
 
 #include "Game.h"
 #include "Offsets.h"
+#include "cursor/Info.h"
+#include "spell/AtCursor.h"
+#include "spell/AtUnit.h"
 #include "tick/WorldTick.h"
 #include "unit/Focus.h"
 
@@ -82,12 +114,10 @@ int CallScript(uintptr_t fn, void *L) {
     return reinterpret_cast<ScriptFn_t>(fn)(L);
 }
 
-// Private keys on the frame's own Lua table. The leading control byte can't be
-// produced by a lowercased user attribute name, so these never collide with a
-// real attribute: kAttrKey holds the attribute subtable, kClickWiredKey latches
-// the one-time OnClick install.
+// Private key on the frame's own Lua table for the attribute subtable. The
+// leading control byte can't be produced by a lowercased user attribute name,
+// so it never collides with a real attribute.
 constexpr const char kAttrKey[] = "\1ClassicAPIAttributes";
-constexpr const char kClickWiredKey[] = "\1ClassicAPIClickWired";
 
 // ---- small string helpers --------------------------------------------------
 
@@ -202,31 +232,128 @@ uint64_t ResolveToken(const char *token) {
         static_cast<uintptr_t>(Offsets::FUN_TOKEN_TO_GUID))(token);
 }
 
-// Set the player's target to `guid` (the engine's own target-by-GUID setter).
-void TargetGuid(uint64_t guid) {
-    if (guid == 0)
-        return;
-    reinterpret_cast<void(__fastcall *)(uint64_t *)>(
-        static_cast<uintptr_t>(Offsets::FUN_TARGET_BY_GUID))(&guid);
+// ---- Lua-global call helpers (used by the click dispatcher) -----------------
+//
+// The click dispatch mirrors retail's SecureActionButton_OnClick: it's C. It
+// performs engine actions by calling ordinary Lua globals (TargetUnit,
+// IsAltKeyDown, …) and our own actions by calling the C++ module directly
+// (Spell::AtUnit, Unit::Focus). Both run under the engine's protected OnClick
+// invocation, so a Lua error inside one is caught there (no crash).
+
+// Pushes _G[name]; leaves it on the stack and returns true only if it's a
+// function (otherwise pops it and returns false).
+bool PushGlobalFunc(void *L, const char *name) {
+    Game::Lua::PushString(L, name);
+    Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);
+    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_FUNCTION)
+        return true;
+    Game::Lua::SetTop(L, Game::Lua::GetTop(L) - 1);
+    return false;
 }
 
-// The GUID a unit is currently targeting (its UNIT_FIELD_TARGET), or 0.
-uint64_t UnitTargetGuid(uint64_t guid) {
-    if (guid == 0)
-        return 0;
-    auto resolve = reinterpret_cast<void *(__fastcall *)(int, const char *, uint32_t,
-                                                         uint32_t, int)>(
-        static_cast<uintptr_t>(Offsets::FUN_OBJECT_RESOLVE_BY_GUID));
-    auto *obj = static_cast<uint8_t *>(
-        resolve(Offsets::OBJ_TYPE_UNIT, "ClassicAPI", static_cast<uint32_t>(guid),
-                static_cast<uint32_t>(guid >> 32), 0x6e));
-    if (obj == nullptr)
-        return 0;
-    auto *fields = *reinterpret_cast<uint8_t *const *>(
-        obj + Offsets::OFF_CGUNIT_OBJECT_FIELDS);
-    if (fields == nullptr)
-        return 0;
-    return *reinterpret_cast<const uint64_t *>(fields + Offsets::OFF_UNIT_FIELD_TARGET);
+// _G[name]() -> boolean (false if the global isn't a function).
+bool CallBoolGlobal(void *L, const char *name) {
+    const int top = Game::Lua::GetTop(L);
+    bool r = false;
+    if (PushGlobalFunc(L, name)) {
+        Game::Lua::Call(L, 0, 1);
+        r = Game::Lua::ToBoolean(L, -1) != 0;
+    }
+    Game::Lua::SetTop(L, top);
+    return r;
+}
+
+// _G[name]() — no args, no results.
+void CallGlobal(void *L, const char *name) {
+    const int top = Game::Lua::GetTop(L);
+    if (PushGlobalFunc(L, name))
+        Game::Lua::Call(L, 0, 0);
+    Game::Lua::SetTop(L, top);
+}
+
+// _G[name](arg) — one string arg, no results. Returns true iff the global was a
+// function and got called (false when it's absent), so callers can fall back.
+bool CallGlobalStr(void *L, const char *name, const char *arg) {
+    const int top = Game::Lua::GetTop(L);
+    const bool called = PushGlobalFunc(L, name);
+    if (called) {
+        Game::Lua::PushString(L, arg);
+        Game::Lua::Call(L, 1, 0);
+    }
+    Game::Lua::SetTop(L, top);
+    return called;
+}
+
+// ---- macrotext execution (stock ChatEdit_ParseText, no addon dependency) ----
+//
+// 1.12 has no `RunMacroText`/`RunMacro` global — those are addon shims (pfUI
+// wraps `ChatEdit_ParseText`; SuperCleveRoidMacros ships its own `RunMacro`).
+// To run macro text without depending on an addon, we replicate pfUI's shim in
+// C: build a throwaway "edit box" whose `GetText` returns the line and whose
+// every other method is a harmless no-op (via an `__index` metamethod), then
+// hand it to the stock FrameXML `ChatEdit_ParseText(editBox, 1)` — the same
+// path the real chat box uses to dispatch a slash command / send a line.
+
+// GetText: returns upvalue(1), the captured line.
+int __fastcall MacroGetText_c(void *L) {
+    Game::Lua::PushValue(L, Game::Lua::UpvalueIndex(1));
+    return 1;
+}
+
+// A no-op standing in for any edit-box method the parser happens to call.
+int __fastcall MacroNoop_c(void *) { return 0; }
+
+// __index(tab, key): hand back the no-op so `editBox:AnyMethod()` is safe.
+int __fastcall MacroIndex_c(void *L) {
+    Game::Lua::PushCClosure(L, &MacroNoop_c, 0);
+    return 1;
+}
+
+// Runs a single macro line through the stock chat parser.
+void RunMacroLineC(void *L, const char *line, size_t len) {
+    if (len == 0) return;
+    const int top = Game::Lua::GetTop(L);
+
+    Game::Lua::NewTable(L);                    // fake editBox
+    const int obj = Game::Lua::GetTop(L);
+
+    Game::Lua::PushString(L, "GetText");       // obj.GetText = closure over line
+    Game::Lua::PushLString(L, line, static_cast<unsigned int>(len));
+    Game::Lua::PushCClosure(L, &MacroGetText_c, 1);
+    Game::Lua::SetTable(L, obj);
+
+    Game::Lua::NewTable(L);                     // metatable { __index = noop }
+    const int mt = Game::Lua::GetTop(L);
+    Game::Lua::PushString(L, "__index");
+    Game::Lua::PushCClosure(L, &MacroIndex_c, 0);
+    Game::Lua::SetTable(L, mt);
+
+    // No lua_setmetatable binding — use the Lua global.
+    if (PushGlobalFunc(L, "setmetatable")) {
+        Game::Lua::PushValue(L, obj);
+        Game::Lua::PushValue(L, mt);
+        Game::Lua::Call(L, 2, 0);
+    }
+
+    if (PushGlobalFunc(L, "ChatEdit_ParseText")) {
+        Game::Lua::PushValue(L, obj);
+        Game::Lua::PushNumber(L, 1);           // send = 1
+        Game::Lua::Call(L, 2, 0);
+    }
+
+    Game::Lua::SetTop(L, top);
+}
+
+// Runs macro text one line at a time — a real macro is line-delimited, and a
+// single ChatEdit_ParseText call only dispatches one command.
+void RunMacroTextC(void *L, const char *text) {
+    if (!text) return;
+    for (const char *p = text; *p;) {
+        const char *nl = p;
+        while (*nl && *nl != '\n') ++nl;
+        RunMacroLineC(L, p, static_cast<size_t>(nl - p));
+        p = (*nl == '\n') ? nl + 1 : nl;
+    }
 }
 
 // ---- mouse-focus poll (drives the native mouseover slot) -------------------
@@ -288,53 +415,161 @@ void ChainOld(void *L) {
     }
 }
 
+// Builds the modifier prefix ("alt-"/"ctrl-"/"shift-", in that order — retail's
+// order) from the live key state, e.g. "alt-shift-". Empty when none held.
+void BuildModifierPrefix(void *L, char *buf, size_t n) {
+    buf[0] = '\0';
+    size_t i = 0;
+    auto add = [&](const char *s) {
+        for (const char *p = s; *p && i + 1 < n; ++p)
+            buf[i++] = *p;
+        buf[i] = '\0';
+    };
+    if (CallBoolGlobal(L, "IsAltKeyDown"))     add("alt-");
+    if (CallBoolGlobal(L, "IsControlKeyDown")) add("ctrl-");
+    if (CallBoolGlobal(L, "IsShiftKeyDown"))   add("shift-");
+}
+
+// Button name -> attribute suffix (retail's convention: the button number).
+const char *ButtonSuffix(const char *btn) {
+    if (EqI(btn, "RightButton"))  return "2";
+    if (EqI(btn, "MiddleButton")) return "3";
+    if (EqI(btn, "Button4"))      return "4";
+    if (EqI(btn, "Button5"))      return "5";
+    return "1"; // LeftButton / unknown
+}
+
+// Resolves a modified attribute into `buf`. Precedence (practical subset of the
+// GetAttribute wildcard rules): prefix..name..suffix (e.g. "shift-type1"),
+// then name..suffix ("type1"), then name ("type"). So a plain `type1` still
+// applies under any modifier unless a modifier-specific attribute overrides it.
+bool ReadModAttr(void *L, int fi, const char *prefix, const char *name,
+                 const char *suffix, char *buf, size_t n) {
+    char key[128];
+    Compose3Lower(key, sizeof key, prefix, name, suffix);
+    if (CopyAttr(L, fi, key, buf, n)) return true;
+    Compose3Lower(key, sizeof key, "", name, suffix);
+    if (CopyAttr(L, fi, key, buf, n)) return true;
+    Compose3Lower(key, sizeof key, "", name, "");
+    return CopyAttr(L, fi, key, buf, n);
+}
+
+// Performs the resolved `verb` on `unit` (a token attribute value, may be null).
+// Returns true if it owned the click (so the chained handler is skipped).
+bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
+                  const char *verb, const char *unit) {
+    if (EqI(verb, "target")) {
+        if (!unit) return false;
+        // Cursor / pending-spell take precedence, matching the engine's default
+        // unit interaction — cast the pending spell / drop the item on the unit
+        // instead of switching target. The two predicates are ours (direct C++);
+        // the actions are engine-only, so they go through the Lua globals (which
+        // are the engine's own entries, with token→GUID resolution).
+        if (Spell::AtCursor::IsPlacementActive())
+            CallGlobalStr(L, "SpellTargetUnit", unit);
+        else if (Cursor::Info::HasItem())
+            CallGlobalStr(L, "DropItemOnUnit", unit);
+        else
+            CallGlobalStr(L, "TargetUnit", unit);
+        return true;
+    }
+    if (EqI(verb, "assist")) {
+        if (!unit) return false;
+        CallGlobalStr(L, "AssistUnit", unit);
+        return true;
+    }
+    if (EqI(verb, "focus")) {
+        if (!unit) return false;
+        Unit::Focus::Set(ResolveToken(unit));
+        return true;
+    }
+    if (EqI(verb, "spell")) {
+        if (!unit) return false;
+        char spell[128];
+        if (!ReadModAttr(L, fi, prefix, "spell", suffix, spell, sizeof spell))
+            return false;
+        Spell::AtUnit::CastByName(spell, unit);
+        return true;
+    }
+    if (EqI(verb, "macro")) {
+        char macro[512];
+        if (!ReadModAttr(L, fi, prefix, "macrotext", suffix, macro, sizeof macro) &&
+            !ReadModAttr(L, fi, prefix, "macro", suffix, macro, sizeof macro))
+            return false;
+        // Prefer an addon-provided RunMacro (SuperCleveRoidMacros, pfUI, …) — it
+        // handles named macros and extended macro text; fall back to the stock
+        // ChatEdit_ParseText path when no RunMacro global is present.
+        if (!CallGlobalStr(L, "RunMacro", macro))
+            RunMacroTextC(L, macro);
+        return true;
+    }
+    if (EqI(verb, "stop") || EqI(verb, "stopcasting")) {
+        CallGlobal(L, "SpellStopCasting");
+        return true;
+    }
+    if (EqI(verb, "menu") || EqI(verb, "togglemenu")) {
+        if (!unit) return false;
+        // The unit dropdown is pure FrameXML work (UnitPopup + ToggleDropDown),
+        // so it lives in the !!!ClassicAPI addon; we just pop it at the cursor.
+        CallGlobalStr(L, "ClassicAPI_ToggleUnitMenu", unit);
+        return true;
+    }
+    // Unknown verb → not handled here; the chained handler runs.
+    return false;
+}
+
 // The chained OnClick handler. Upvalues: 1 = previous handler (or nil), 2 = the
 // frame (captured at install time, so we don't depend on the `this` global).
+// Resolves one verb per click from the (modifier/button) `type` attribute and
+// performs it — retail's one-action-per-click model. Only chains the previous
+// handler when we DIDN'T own the click, so a configured `type1` no longer runs
+// alongside the addon's own OnClick (that double-dispatch was the conflict).
 int __fastcall OnClick_c(void *L) {
     const int top = Game::Lua::GetTop(L);
     Game::Lua::PushValue(L, Game::Lua::UpvalueIndex(2)); // frame
     const int fi = Game::Lua::GetTop(L);
+    bool handled = false;
     if (Game::Lua::Type(L, fi) == Game::Lua::TYPE_TABLE) {
-        char unit[128];
-        if (CopyAttr(L, fi, "unit", unit, sizeof unit)) {
-            // Which button — from the OnClick `arg1` global.
-            char btn[32] = {0};
-            Game::Lua::PushString(L, "arg1");
-            Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);
-            if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_STRING) {
-                const char *b = Game::Lua::ToString(L, -1);
-                if (b)
-                    BoundedCopy(btn, b, sizeof btn);
-            }
-            Game::Lua::SetTop(L, fi); // drop arg1, keep frame
+        char btn[32] = {0};
+        Game::Lua::PushString(L, "arg1");
+        Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);
+        if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_STRING) {
+            const char *b = Game::Lua::ToString(L, -1);
+            if (b)
+                BoundedCopy(btn, b, sizeof btn);
+        }
+        Game::Lua::SetTop(L, fi); // drop arg1, keep frame
 
-            const char *tkey = EqI(btn, "RightButton") ? "type2"
-                               : EqI(btn, "LeftButton") ? "type1"
-                                                        : "type";
-            char verb[32] = {0};
-            if (CopyAttr(L, fi, tkey, verb, sizeof verb) ||
-                CopyAttr(L, fi, "type", verb, sizeof verb)) {
-                const uint64_t guid = ResolveToken(unit);
-                if (guid != 0) {
-                    if (EqI(verb, "target"))
-                        TargetGuid(guid);
-                    else if (EqI(verb, "assist"))
-                        TargetGuid(UnitTargetGuid(guid));
-                    else if (EqI(verb, "focus"))
-                        Unit::Focus::Set(guid);
-                    // togglemenu / spell / macro not backported yet.
-                }
-            }
+        const char *suffix = ButtonSuffix(btn);
+        char prefix[24];
+        BuildModifierPrefix(L, prefix, sizeof prefix);
+
+        char verb[32];
+        if (ReadModAttr(L, fi, prefix, "type", suffix, verb, sizeof verb)) {
+            char unit[128];
+            const bool haveUnit =
+                ReadModAttr(L, fi, prefix, "unit", suffix, unit, sizeof unit);
+            handled = DispatchVerb(L, fi, prefix, suffix, verb,
+                                   haveUnit ? unit : nullptr);
         }
     }
     Game::Lua::SetTop(L, top);
-    ChainOld(L);
+    if (!handled)
+        ChainOld(L); // let the frame's own OnClick handle unconfigured clicks
     return 0;
 }
 
 // Installs OnClick as a closure over (previous handler, frame). Operates on
 // self at stack index 1. Raises if `self` isn't a Button (OnClick is a Button
 // script) — callers run it under PCall.
+//
+// Self-healing against clobbering: addons re-`SetScript("OnClick", …)` their
+// own handler (pfUI does it on every raid relayout via UpdateScripts), which
+// replaces our closure. So we re-wire whenever a `type*` attribute is (re)set,
+// but only when the current OnClick is a *Lua* handler (a real clobber) or nil
+// — if it's already a C function it's our own closure, and re-wrapping would
+// double-chain. `IsCFunction` cleanly distinguishes the two here (addon click
+// handlers are Lua; the only C-function OnClick we ever see is ours).
 int __fastcall WireOnClick(void *L) {
     Game::Lua::SetTop(L, 1);                             // (self)
     Game::Lua::PushString(L, "OnClick");                 // (self, name)
@@ -342,31 +577,97 @@ int __fastcall WireOnClick(void *L) {
     if (Game::Lua::GetTop(L) < 3)                        // defensive
         Game::Lua::PushNil(L);
     Game::Lua::SetTop(L, 3);                             // (self, name, old|nil)
+    if (Game::Lua::Type(L, 3) == Game::Lua::TYPE_FUNCTION &&
+        Game::Lua::IsCFunction(L, 3) != 0)
+        return 0;                                        // already our closure
     Game::Lua::PushValue(L, 1);                          // (self, name, old, self)
     Game::Lua::PushCClosure(L, &OnClick_c, 2);           // upvalues (old, self)
     CallScript(Offsets::FUN_SCRIPT_FRAME_SETSCRIPT, L);
     return 0;
 }
 
-// Returns true if the frame's OnClick was already wired by us; otherwise
-// latches the flag and returns false.
-bool ClickAlreadyWired(void *L, int frameIdx) {
-    const int top = Game::Lua::GetTop(L);
-    bool already = false;
-    if (PushSub(L, frameIdx, true)) {        // [.., sub]
-        const int si = Game::Lua::GetTop(L);
-        Game::Lua::PushString(L, kClickWiredKey);
-        Game::Lua::RawGet(L, si);            // [.., sub, flag]
-        already = Game::Lua::ToBoolean(L, -1) != 0;
-        Game::Lua::SetTop(L, si);            // [.., sub]
-        if (!already) {
-            Game::Lua::PushString(L, kClickWiredKey);
-            Game::Lua::PushBoolean(L, 1);
-            Game::Lua::RawSet(L, si);        // sub[wired] = true
-        }
-    }
-    Game::Lua::SetTop(L, top);
-    return already;
+// ---- OnAttributeChanged script (settable via SetScript, like retail) --------
+//
+// Backport of the modern `OnAttributeChanged` widget script: SetAttribute (but
+// NOT SetAttributeNoHandler) fires the frame's OnAttributeChanged handler. 1.12
+// has no such script, so we make it SetScript/GetScript/HookScript-able the same
+// way Tooltip::SetEvents adds OnTooltipSet* — co-hook the frame script-name
+// resolver (FUN_FRAME_SCRIPT_RESOLVER, the base every frame type delegates to)
+// and, for the one name the engine doesn't know, hand back an external 8-byte
+// {handler, context} cell. Frames are immortal in 1.12 (no destroy), so a cell
+// keyed by the frame's C object pointer never goes stale.
+//
+// 1.12 passes script args as globals, not params (see OnClick_c reading arg1),
+// so we fire with `this` = frame (bound by the invoker), `arg1` = name and
+// `arg2` = the new value: `function() local name, value = arg1, arg2 … end`.
+
+struct AttrScriptSlot { uint32_t v[2]; }; // {handler, exec context}
+std::unordered_map<const void *, AttrScriptSlot> g_attrHandlers;
+
+uint32_t *AttrSlotFor(const void *frame, bool create) {
+    auto it = g_attrHandlers.find(frame);
+    if (it != g_attrHandlers.end())
+        return it->second.v;
+    if (!create)
+        return nullptr;
+    AttrScriptSlot &s = g_attrHandlers[frame]; // node-based → stable address
+    s.v[0] = 0;
+    s.v[1] = 0;
+    return s.v;
+}
+
+// Resolver co-hook. The engine's __thiscall(frame, name) is modelled as
+// __fastcall with a dummy edx — `name` lands on the first stack slot either way
+// (same trick as Tooltip::SetEvents). The original returns 0 for a name it
+// doesn't know; we then claim "OnAttributeChanged".
+using FrameResolver_t = int(__fastcall *)(void *frame, void *edx, const char *name);
+FrameResolver_t g_frameResolverOriginal = nullptr;
+
+int __fastcall FrameResolver_h(void *frame, void *edx, const char *name) {
+    const int slot = g_frameResolverOriginal(frame, edx, name);
+    if (slot != 0) // a real base-frame / subtype script — leave it
+        return slot;
+    if (EqI(name, "onattributechanged"))
+        return reinterpret_cast<int>(AttrSlotFor(frame, /*create*/ true));
+    return 0;
+}
+
+const Game::HookAutoRegister _attrResolverHook{
+    Offsets::FUN_FRAME_SCRIPT_RESOLVER,
+    reinterpret_cast<void *>(&FrameResolver_h),
+    reinterpret_cast<void **>(&g_frameResolverOriginal)};
+
+// Fire OnAttributeChanged on `frame`, with arg1 = name and arg2 = the new value
+// (still at stack[3] in DoSet). Recursion-guarded so a handler that itself calls
+// SetAttribute doesn't loop. The invoker (FUN_FRAME_INVOKE_SCRIPT) binds `this`
+// and runs the handler under its own protected pcall; it doesn't restore the
+// stack top, so snapshot/restore around it (as Tooltip::SetEvents does).
+int g_firingAttr = 0;
+
+using InvokeAttrScript_t = void(__fastcall *)(uint32_t handler, void *frame);
+
+void FireAttributeChanged(void *L, void *frame, const char *name) {
+    if (frame == nullptr || g_firingAttr > 0)
+        return;
+    uint32_t *slot = AttrSlotFor(frame, /*create*/ false);
+    if (slot == nullptr || slot[0] == 0)
+        return;
+
+    const int savedTop = Game::Lua::GetTop(L);
+    Game::Lua::PushString(L, "arg1");
+    Game::Lua::PushString(L, name);
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);           // _G.arg1 = name
+    Game::Lua::PushString(L, "arg2");
+    if (savedTop >= 3)
+        Game::Lua::PushValue(L, 3);
+    else
+        Game::Lua::PushNil(L);
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);           // _G.arg2 = value
+
+    ++g_firingAttr;
+    reinterpret_cast<InvokeAttrScript_t>(Offsets::FUN_FRAME_INVOKE_SCRIPT)(slot[0], frame);
+    --g_firingAttr;
+    Game::Lua::SetTop(L, savedTop);
 }
 
 // ---- the methods -----------------------------------------------------------
@@ -379,7 +680,7 @@ void EnableFrameMouse(void *L) {
     CallScript(Offsets::FUN_SCRIPT_FRAME_ENABLEMOUSE, L);
 }
 
-int DoSet(void *L) { // (self, name, value)
+int DoSet(void *L, bool fireHandler) { // (self, name, value)
     if (!Game::Lua::IsString(L, 2)) {
         Game::Lua::Error(L, "Usage: frame:SetAttribute(\"name\", value)");
         return 0;
@@ -414,22 +715,27 @@ int DoSet(void *L) { // (self, name, value)
             }
         }
     }
-    // A `type*` attribute makes the frame a clickable unit button: install a
-    // chained OnClick once (PCall-guarded — OnClick is Button-only). The
-    // handler reads the attributes fresh at click time, so setting type1 then
-    // type2 needs no re-wire.
+    // A `type*` attribute makes the frame a clickable unit button: (re)install
+    // the chained OnClick (PCall-guarded — OnClick is Button-only). WireOnClick
+    // is idempotent and self-healing, so calling it on every `type*` set both
+    // avoids double-chaining and reinstalls after an addon clobbered our
+    // OnClick — set `type*` again after re-SetScript to recover. The handler
+    // reads all the attributes fresh at click time.
     else if ((std::strcmp(lname, "type1") == 0 || std::strcmp(lname, "type2") == 0 ||
               std::strcmp(lname, "type") == 0) &&
-             isString && !ClickAlreadyWired(L, 1)) {
+             isString) {
         Game::Lua::PushCClosure(L, &WireOnClick, 0);
         Game::Lua::PushValue(L, 1); // arg = self
         Game::Lua::PCall(L, 1, 0, 0); // ignore errors (non-Button frame)
     }
+
+    if (fireHandler)
+        FireAttributeChanged(L, Game::Lua::ResolveObject(L, 1), lname);
     return 0;
 }
 
-int __fastcall Script_SetAttribute(void *L) { return DoSet(L); }
-int __fastcall Script_SetAttributeNoHandler(void *L) { return DoSet(L); }
+int __fastcall Script_SetAttribute(void *L) { return DoSet(L, /*fireHandler*/ true); }
+int __fastcall Script_SetAttributeNoHandler(void *L) { return DoSet(L, /*fireHandler*/ false); }
 
 int __fastcall Script_GetAttribute(void *L) {
     if (!Game::Lua::IsString(L, 2)) {

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -1,0 +1,487 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+// Frame attributes + unit-frame mouseover/click backport.
+//
+// Backports `frame:SetAttribute` / `frame:SetAttributeNoHandler` /
+// `frame:GetAttribute` to 1.12 as native methods on the base Frame registry
+// (every frame gets them, like the modern clients). Vanilla has no attribute
+// system at all — it arrived in 2.0 with secure frames. Attributes are just a
+// per-frame, case-insensitive key→value store (verified from the 3.3.5
+// implementation: a name→Lua-value map plus a getter with prefix/name/suffix
+// wildcard precedence). We store the map on the frame's own Lua table under a
+// private key, so it's collected with the frame.
+//
+// The headline use — SecureUnitButton behavior, minus the secure wrapper (1.12
+// has no combat lockdown or taint, so protected actions just work):
+//
+//     unitFrame:SetAttribute("unit", "party1")   -- hover → mouseover = party1
+//     unitFrame:SetAttribute("type1", "target")  -- left-click → target party1
+//
+// ── Mouseover (needs C — the engine's mouseover is a GUID slot) ──
+//
+// Installing OnEnter/OnLeave would be clobbered by an addon's own
+// `SetScript("OnEnter", …)` (pfUI sets `unit` before its scripts), and there's
+// nothing to read from Lua anyway — the mouseover unit is an engine global. So
+// we mirror retail / SuperWoW's `SetMouseoverUnit`: watch the engine's
+// mouse-focus frame (`*(*VAR_UI_CONTEXT_PTR + OFF_UI_CONTEXT_MOUSE_FOCUS)`, the
+// CFrameScriptObject* `GetMouseFocus` returns) once per frame on the shared
+// WorldTick, and when it's a `unit`-attributed frame call the engine's FULL
+// mouseover setter (FUN_00492890) — 1:1 with hovering the unit's 3D model:
+// model highlight, mouseover tooltip, UPDATE_MOUSEOVER_UNIT, and the GUID slot.
+// Stomp-proof: the engine's own 3D-hover setter is event-driven, so nothing
+// overwrites the slot while the cursor is over UI.
+//
+// ── Clicks (the frame's own OnClick — scoped, native) ──
+//
+// Clicks are events, not state, so they belong on the frame's OnClick — but
+// ONLY on frames that opt in with a `type` attribute. When a `type*` attribute
+// is first set we install a chained OnClick on that frame (protected, because
+// OnClick is Button-only); it reads `unit` + `type1`/`type2`/`type` at click
+// time and performs the action, then runs any previously-set handler. Verbs:
+// `target`, `assist` (target the unit's target), `focus`. No global hook, no
+// per-frame handler on frames that never asked for one.
+//
+// Ordering: because it chains the handler present when `type*` is set, set the
+// `type` attribute AFTER the frame's own `OnClick` (real addons configure
+// attributes after building the widget). The frame must be a Button registered
+// for the relevant clicks (`RegisterForClicks`) — left is the Button default;
+// right needs `RegisterForClicks("RightButtonUp")`, which real unit frames do.
+//
+// NOT DONE: `OnAttributeChanged` as a real SetScript-able handler — needs a
+// base-frame script-name resolver co-hook (the `Tooltip::SetEvents` analog).
+
+#include "Game.h"
+#include "Offsets.h"
+#include "tick/WorldTick.h"
+#include "unit/Focus.h"
+
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+
+namespace Frame::Attributes {
+
+namespace {
+
+using ScriptFn_t = int(__fastcall *)(void *L);
+
+int CallScript(uintptr_t fn, void *L) {
+    return reinterpret_cast<ScriptFn_t>(fn)(L);
+}
+
+// Private keys on the frame's own Lua table. The leading control byte can't be
+// produced by a lowercased user attribute name, so these never collide with a
+// real attribute: kAttrKey holds the attribute subtable, kClickWiredKey latches
+// the one-time OnClick install.
+constexpr const char kAttrKey[] = "\1ClassicAPIAttributes";
+constexpr const char kClickWiredKey[] = "\1ClassicAPIClickWired";
+
+// ---- small string helpers --------------------------------------------------
+
+void LowerCopy(char *dst, const char *src, size_t n) {
+    size_t i = 0;
+    for (; src && src[i] && i + 1 < n; ++i)
+        dst[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(src[i])));
+    dst[i] = '\0';
+}
+
+// Bounded, always-terminated copy (avoids the C4996 strncpy/strcpy warnings).
+void BoundedCopy(char *dst, const char *src, size_t n) {
+    size_t i = 0;
+    for (; src && src[i] && i + 1 < n; ++i)
+        dst[i] = src[i];
+    dst[i] = '\0';
+}
+
+// dst = tolower(a .. b .. c). Truncates at n-1.
+void Compose3Lower(char *dst, size_t n, const char *a, const char *b, const char *c) {
+    size_t i = 0;
+    const char *parts[3] = {a, b, c};
+    for (const char *s : parts)
+        for (; s && *s && i + 1 < n; ++s)
+            dst[i++] = static_cast<char>(std::tolower(static_cast<unsigned char>(*s)));
+    dst[i] = '\0';
+}
+
+// ASCII case-insensitive full-string equality.
+bool EqI(const char *a, const char *b) {
+    for (; *a && *b; ++a, ++b)
+        if (std::tolower(static_cast<unsigned char>(*a)) !=
+            std::tolower(static_cast<unsigned char>(*b)))
+            return false;
+    return *a == *b;
+}
+
+// ---- attribute storage (on the frame's own Lua table) ----------------------
+
+// Pushes frame[kAttrKey] (the attribute subtable) onto the stack. With
+// create=true, lazily creates and stores it. Returns true iff a subtable is
+// left on top; false (nothing left on the stack) when absent and !create.
+bool PushSub(void *L, int frameIdx, bool create) {
+    Game::Lua::PushValue(L, frameIdx);      // [.., frame]
+    const int f = Game::Lua::GetTop(L);
+    Game::Lua::PushString(L, kAttrKey);      // [.., frame, key]
+    Game::Lua::RawGet(L, f);                 // [.., frame, sub|nil]
+    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_TABLE) {
+        Game::Lua::Remove(L, f);             // [.., sub]
+        return true;
+    }
+    Game::Lua::SetTop(L, f);                 // [.., frame]   (drop the nil)
+    if (!create) {
+        Game::Lua::SetTop(L, f - 1);         // [..]          (drop frame)
+        return false;
+    }
+    Game::Lua::NewTable(L);                   // [.., frame, sub]
+    Game::Lua::PushString(L, kAttrKey);       // [.., frame, sub, key]
+    Game::Lua::PushValue(L, f + 1);           // [.., frame, sub, key, sub]
+    Game::Lua::RawSet(L, f);                  // frame[key] = sub -> [.., frame, sub]
+    Game::Lua::Remove(L, f);                  // [.., sub]
+    return true;
+}
+
+// Copies string attribute `lname` (already lowercase) of the frame at
+// frameIdx into buf. Returns true iff a string value was found. Restores the
+// stack.
+bool CopyAttr(void *L, int frameIdx, const char *lname, char *buf, size_t n) {
+    const int top = Game::Lua::GetTop(L);
+    bool ok = false;
+    if (PushSub(L, frameIdx, false)) {       // [.., sub]
+        const int si = Game::Lua::GetTop(L);
+        Game::Lua::PushString(L, lname);
+        Game::Lua::RawGet(L, si);            // [.., sub, val]
+        if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_STRING) {
+            const char *s = Game::Lua::ToString(L, -1);
+            if (s) {
+                BoundedCopy(buf, s, n);
+                ok = true;
+            }
+        }
+    }
+    Game::Lua::SetTop(L, top);
+    return ok;
+}
+
+// If frame[kAttrKey][keyLower] is non-nil, leave that value on the stack top
+// and return true; otherwise restore the stack and return false.
+bool TryPushValue(void *L, int frameIdx, const char *keyLower) {
+    const int top = Game::Lua::GetTop(L);
+    if (PushSub(L, frameIdx, false)) {       // [.., sub]
+        const int si = Game::Lua::GetTop(L);
+        Game::Lua::PushString(L, keyLower);
+        Game::Lua::RawGet(L, si);            // [.., sub, val]
+        if (Game::Lua::Type(L, -1) != Game::Lua::TYPE_NIL) {
+            Game::Lua::Remove(L, si);        // [.., val]
+            return true;
+        }
+    }
+    Game::Lua::SetTop(L, top);
+    return false;
+}
+
+// ---- engine primitives -----------------------------------------------------
+
+// Resolve a unit token/GUID to a GUID via the hooked resolver (handles
+// player/target/party/raid plus our focus / nameplateN / raw-GUID extensions).
+// For recognized tokens this never raises; unit attributes are tokens by
+// contract.
+uint64_t ResolveToken(const char *token) {
+    return reinterpret_cast<uint64_t(__fastcall *)(const char *)>(
+        static_cast<uintptr_t>(Offsets::FUN_TOKEN_TO_GUID))(token);
+}
+
+// Set the player's target to `guid` (the engine's own target-by-GUID setter).
+void TargetGuid(uint64_t guid) {
+    if (guid == 0)
+        return;
+    reinterpret_cast<void(__fastcall *)(uint64_t *)>(
+        static_cast<uintptr_t>(Offsets::FUN_TARGET_BY_GUID))(&guid);
+}
+
+// The GUID a unit is currently targeting (its UNIT_FIELD_TARGET), or 0.
+uint64_t UnitTargetGuid(uint64_t guid) {
+    if (guid == 0)
+        return 0;
+    auto resolve = reinterpret_cast<void *(__fastcall *)(int, const char *, uint32_t,
+                                                         uint32_t, int)>(
+        static_cast<uintptr_t>(Offsets::FUN_OBJECT_RESOLVE_BY_GUID));
+    auto *obj = static_cast<uint8_t *>(
+        resolve(Offsets::OBJ_TYPE_UNIT, "ClassicAPI", static_cast<uint32_t>(guid),
+                static_cast<uint32_t>(guid >> 32), 0x6e));
+    if (obj == nullptr)
+        return 0;
+    auto *fields = *reinterpret_cast<uint8_t *const *>(
+        obj + Offsets::OFF_CGUNIT_OBJECT_FIELDS);
+    if (fields == nullptr)
+        return 0;
+    return *reinterpret_cast<const uint64_t *>(fields + Offsets::OFF_UNIT_FIELD_TARGET);
+}
+
+// ---- mouse-focus poll (drives the native mouseover slot) -------------------
+
+// frame CFrameScriptObject* → current `unit` token, for the mouse-focus poll.
+// Keyed by the same pointer the engine stores at the mouse-focus slot. Single-
+// threaded (Lua + WorldTick on the main thread), so no synchronization needed.
+std::unordered_map<const void *, std::string> g_unitByFrame;
+
+// The last GUID *we* wrote into the mouseover slot. We only touch the slot on a
+// change of our own value, so when the cursor isn't over a unit frame (guid 0)
+// we never clobber the engine's own 3D mouseover.
+uint64_t g_lastSet = 0;
+
+const void *CurrentMouseFocus() {
+    const void *ctx = *reinterpret_cast<const void *const *>(
+        static_cast<uintptr_t>(Offsets::VAR_UI_CONTEXT_PTR));
+    if (ctx == nullptr)
+        return nullptr;
+    return *reinterpret_cast<const void *const *>(
+        reinterpret_cast<const uint8_t *>(ctx) + Offsets::OFF_UI_CONTEXT_MOUSE_FOCUS);
+}
+
+// The engine's real mouseover setter — `__stdcall(guidLo, guidHi, prevLo,
+// prevHi)`. Highlights the unit's model, builds the mouseover tooltip, fires
+// UPDATE_MOUSEOVER_UNIT, and writes the GUID slot; pass 0,0 for the optional
+// previous, and (0,0,0,0) to clear. Same address `Unit::Mouseover` co-hooks, so
+// calling it here goes through that hook (loss events keep firing correctly).
+void CallEngineMouseover(uint64_t guid) {
+    reinterpret_cast<void(__stdcall *)(uint32_t, uint32_t, uint32_t, uint32_t)>(
+        static_cast<uintptr_t>(Offsets::FUN_SET_MOUSEOVER_UNIT))(
+        static_cast<uint32_t>(guid), static_cast<uint32_t>(guid >> 32), 0, 0);
+}
+
+void MouseoverTick() {
+    const void *focus = CurrentMouseFocus();
+
+    uint64_t guid = 0;
+    if (focus != nullptr) {
+        auto it = g_unitByFrame.find(focus);
+        if (it != g_unitByFrame.end())
+            guid = ResolveToken(it->second.c_str()); // live — follows target changes
+    }
+
+    if (guid != g_lastSet) {
+        CallEngineMouseover(guid); // sets slot + highlight + tooltip + event
+        g_lastSet = guid;
+    }
+}
+
+// ---- click dispatch (the frame's own chained OnClick) ----------------------
+
+// Runs the chained-onto previous handler (upvalue 1), vanilla-style with no
+// args (it reads the `this`/`arg1` globals the engine set for this invocation).
+void ChainOld(void *L) {
+    if (Game::Lua::Type(L, Game::Lua::UpvalueIndex(1)) == Game::Lua::TYPE_FUNCTION) {
+        Game::Lua::PushValue(L, Game::Lua::UpvalueIndex(1));
+        Game::Lua::Call(L, 0, 0);
+    }
+}
+
+// The chained OnClick handler. Upvalues: 1 = previous handler (or nil), 2 = the
+// frame (captured at install time, so we don't depend on the `this` global).
+int __fastcall OnClick_c(void *L) {
+    const int top = Game::Lua::GetTop(L);
+    Game::Lua::PushValue(L, Game::Lua::UpvalueIndex(2)); // frame
+    const int fi = Game::Lua::GetTop(L);
+    if (Game::Lua::Type(L, fi) == Game::Lua::TYPE_TABLE) {
+        char unit[128];
+        if (CopyAttr(L, fi, "unit", unit, sizeof unit)) {
+            // Which button — from the OnClick `arg1` global.
+            char btn[32] = {0};
+            Game::Lua::PushString(L, "arg1");
+            Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);
+            if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_STRING) {
+                const char *b = Game::Lua::ToString(L, -1);
+                if (b)
+                    BoundedCopy(btn, b, sizeof btn);
+            }
+            Game::Lua::SetTop(L, fi); // drop arg1, keep frame
+
+            const char *tkey = EqI(btn, "RightButton") ? "type2"
+                               : EqI(btn, "LeftButton") ? "type1"
+                                                        : "type";
+            char verb[32] = {0};
+            if (CopyAttr(L, fi, tkey, verb, sizeof verb) ||
+                CopyAttr(L, fi, "type", verb, sizeof verb)) {
+                const uint64_t guid = ResolveToken(unit);
+                if (guid != 0) {
+                    if (EqI(verb, "target"))
+                        TargetGuid(guid);
+                    else if (EqI(verb, "assist"))
+                        TargetGuid(UnitTargetGuid(guid));
+                    else if (EqI(verb, "focus"))
+                        Unit::Focus::Set(guid);
+                    // togglemenu / spell / macro not backported yet.
+                }
+            }
+        }
+    }
+    Game::Lua::SetTop(L, top);
+    ChainOld(L);
+    return 0;
+}
+
+// Installs OnClick as a closure over (previous handler, frame). Operates on
+// self at stack index 1. Raises if `self` isn't a Button (OnClick is a Button
+// script) — callers run it under PCall.
+int __fastcall WireOnClick(void *L) {
+    Game::Lua::SetTop(L, 1);                             // (self)
+    Game::Lua::PushString(L, "OnClick");                 // (self, name)
+    CallScript(Offsets::FUN_SCRIPT_FRAME_GETSCRIPT, L);  // (self, name, old)
+    if (Game::Lua::GetTop(L) < 3)                        // defensive
+        Game::Lua::PushNil(L);
+    Game::Lua::SetTop(L, 3);                             // (self, name, old|nil)
+    Game::Lua::PushValue(L, 1);                          // (self, name, old, self)
+    Game::Lua::PushCClosure(L, &OnClick_c, 2);           // upvalues (old, self)
+    CallScript(Offsets::FUN_SCRIPT_FRAME_SETSCRIPT, L);
+    return 0;
+}
+
+// Returns true if the frame's OnClick was already wired by us; otherwise
+// latches the flag and returns false.
+bool ClickAlreadyWired(void *L, int frameIdx) {
+    const int top = Game::Lua::GetTop(L);
+    bool already = false;
+    if (PushSub(L, frameIdx, true)) {        // [.., sub]
+        const int si = Game::Lua::GetTop(L);
+        Game::Lua::PushString(L, kClickWiredKey);
+        Game::Lua::RawGet(L, si);            // [.., sub, flag]
+        already = Game::Lua::ToBoolean(L, -1) != 0;
+        Game::Lua::SetTop(L, si);            // [.., sub]
+        if (!already) {
+            Game::Lua::PushString(L, kClickWiredKey);
+            Game::Lua::PushBoolean(L, 1);
+            Game::Lua::RawSet(L, si);        // sub[wired] = true
+        }
+    }
+    Game::Lua::SetTop(L, top);
+    return already;
+}
+
+// ---- the methods -----------------------------------------------------------
+
+// Enables the frame's mouse so it can become the mouse-focus (a bare frame
+// otherwise never registers as hovered). Operates on self at index 1.
+void EnableFrameMouse(void *L) {
+    Game::Lua::SetTop(L, 1); // (self)
+    Game::Lua::PushBoolean(L, 1);
+    CallScript(Offsets::FUN_SCRIPT_FRAME_ENABLEMOUSE, L);
+}
+
+int DoSet(void *L) { // (self, name, value)
+    if (!Game::Lua::IsString(L, 2)) {
+        Game::Lua::Error(L, "Usage: frame:SetAttribute(\"name\", value)");
+        return 0;
+    }
+    char lname[256];
+    LowerCopy(lname, Game::Lua::ToString(L, 2), sizeof lname);
+
+    if (PushSub(L, 1, true)) {               // [.., sub]
+        const int si = Game::Lua::GetTop(L);
+        Game::Lua::PushString(L, lname);     // [.., sub, key]
+        Game::Lua::PushValue(L, 3);          // [.., sub, key, value]  (nil if absent)
+        Game::Lua::RawSet(L, si);            // sub[lname] = value
+        Game::Lua::SetTop(L, si - 1);        // drop sub
+    }
+
+    const bool isString = Game::Lua::Type(L, 3) == Game::Lua::TYPE_STRING;
+
+    // `unit` drives the mouseover binding: index it by the frame's C object
+    // (the key the mouse-focus poll uses) and enable its mouse so it can be
+    // hovered.
+    if (std::strcmp(lname, "unit") == 0) {
+        void *obj = Game::Lua::ResolveObject(L, 1);
+        if (obj != nullptr) {
+            if (isString) {
+                const char *tok = Game::Lua::ToString(L, 3);
+                const bool isNew = g_unitByFrame.find(obj) == g_unitByFrame.end();
+                g_unitByFrame[obj] = tok ? tok : "";
+                if (isNew)
+                    EnableFrameMouse(L);
+            } else {
+                g_unitByFrame.erase(obj);
+            }
+        }
+    }
+    // A `type*` attribute makes the frame a clickable unit button: install a
+    // chained OnClick once (PCall-guarded — OnClick is Button-only). The
+    // handler reads the attributes fresh at click time, so setting type1 then
+    // type2 needs no re-wire.
+    else if ((std::strcmp(lname, "type1") == 0 || std::strcmp(lname, "type2") == 0 ||
+              std::strcmp(lname, "type") == 0) &&
+             isString && !ClickAlreadyWired(L, 1)) {
+        Game::Lua::PushCClosure(L, &WireOnClick, 0);
+        Game::Lua::PushValue(L, 1); // arg = self
+        Game::Lua::PCall(L, 1, 0, 0); // ignore errors (non-Button frame)
+    }
+    return 0;
+}
+
+int __fastcall Script_SetAttribute(void *L) { return DoSet(L); }
+int __fastcall Script_SetAttributeNoHandler(void *L) { return DoSet(L); }
+
+int __fastcall Script_GetAttribute(void *L) {
+    if (!Game::Lua::IsString(L, 2)) {
+        Game::Lua::Error(L, "Usage: frame:GetAttribute(\"name\")");
+        return 0;
+    }
+    // 3-arg form: (prefix, name, suffix) with wildcard precedence.
+    if (Game::Lua::GetTop(L) >= 4 && Game::Lua::IsString(L, 3)) {
+        const char *pfx = Game::Lua::IsString(L, 2) ? Game::Lua::ToString(L, 2) : "";
+        const char *nm = Game::Lua::ToString(L, 3);
+        const char *sfx = Game::Lua::IsString(L, 4) ? Game::Lua::ToString(L, 4) : "";
+        char key[256];
+        Compose3Lower(key, sizeof key, pfx, nm, sfx);
+        if (TryPushValue(L, 1, key)) return 1;
+        Compose3Lower(key, sizeof key, "*", nm, sfx);
+        if (TryPushValue(L, 1, key)) return 1;
+        Compose3Lower(key, sizeof key, pfx, nm, "*");
+        if (TryPushValue(L, 1, key)) return 1;
+        Compose3Lower(key, sizeof key, "*", nm, "*");
+        if (TryPushValue(L, 1, key)) return 1;
+        Compose3Lower(key, sizeof key, "", nm, "");
+        if (TryPushValue(L, 1, key)) return 1;
+        Game::Lua::PushNil(L);
+        return 1;
+    }
+
+    char lname[256];
+    LowerCopy(lname, Game::Lua::ToString(L, 2), sizeof lname);
+    if (TryPushValue(L, 1, lname))
+        return 1;
+    Game::Lua::PushNil(L);
+    return 1;
+}
+
+// ---- registration ----------------------------------------------------------
+
+const Game::Lua::FrameMethodEntry g_frameMethods[] = {
+    {"SetAttribute", &Script_SetAttribute},
+    {"SetAttributeNoHandler", &Script_SetAttributeNoHandler},
+    {"GetAttribute", &Script_GetAttribute},
+};
+
+void RegisterLuaFunctions() {
+    Game::Lua::RegisterFrameMethods(
+        reinterpret_cast<void *>(Offsets::VAR_FRAME_METHOD_REGISTRY),
+        g_frameMethods,
+        static_cast<int>(sizeof(g_frameMethods) / sizeof(g_frameMethods[0])));
+}
+
+const Game::ModuleAutoRegister _autoreg{&RegisterLuaFunctions};
+const Tick::WorldTick::AutoSubscribe _tick{&MouseoverTick};
+
+} // namespace
+
+} // namespace Frame::Attributes

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -101,6 +101,7 @@
 #include "spell/AtUnit.h"
 #include "tick/WorldTick.h"
 #include "unit/Focus.h"
+#include "unit/Identity.h"
 
 #include <cctype>
 #include <cstdint>
@@ -153,6 +154,30 @@ bool EqI(const char *a, const char *b) {
             std::tolower(static_cast<unsigned char>(*b)))
             return false;
     return *a == *b;
+}
+
+// True if `lname` (already lowercase) is a click "type" action attribute: an
+// optional modifier prefix (alt-/ctrl-/shift-, any order/combo) followed by
+// "type" and an optional button digit — i.e. anything the click resolver
+// (ButtonSuffix + ReadModAttr) reads as a verb selector: type, type1..type5,
+// shift-type1, alt-ctrl-type2, … . This is the exact set WireOnClick must
+// (re)install for; keying the wiring off it (rather than a fixed
+// type/type1/type2 list) means a middle-click (type3) or modifier-only config
+// still installs the chained OnClick.
+bool IsTypeAttr(const char *lname) {
+    const char *p = lname;
+    for (bool advanced = true; advanced;) {
+        if (std::strncmp(p, "alt-", 4) == 0)        p += 4;
+        else if (std::strncmp(p, "ctrl-", 5) == 0)  p += 5;
+        else if (std::strncmp(p, "shift-", 6) == 0) p += 6;
+        else                                        advanced = false;
+    }
+    if (std::strncmp(p, "type", 4) != 0)
+        return false;
+    p += 4;
+    if (p[0] == '\0')
+        return true;                                     // "type"
+    return p[0] >= '1' && p[0] <= '5' && p[1] == '\0';   // "typeN"
 }
 
 // ---- attribute storage (in the Lua registry, keyed by the frame) -----------
@@ -220,16 +245,10 @@ bool TryPushValue(void *L, int frameIdx, const char *keyLower) {
     return false;
 }
 
-// ---- engine primitives -----------------------------------------------------
-
-// Resolve a unit token/GUID to a GUID via the hooked resolver (handles
-// player/target/party/raid plus our focus / nameplateN / raw-GUID extensions).
-// For recognized tokens this never raises; unit attributes are tokens by
-// contract.
-uint64_t ResolveToken(const char *token) {
-    return reinterpret_cast<uint64_t(__fastcall *)(const char *)>(
-        static_cast<uintptr_t>(Offsets::FUN_TOKEN_TO_GUID))(token);
-}
+// Unit token → GUID goes through `Unit::Identity::GuidForToken` (engine
+// resolver + `"player"` fast-path, handling our focus / nameplateN / raw-GUID
+// extensions). For recognized tokens it never raises; unit attributes are
+// tokens by contract.
 
 // ---- Lua-global call helpers (used by the click dispatcher) -----------------
 //
@@ -239,48 +258,23 @@ uint64_t ResolveToken(const char *token) {
 // (Spell::AtUnit, Unit::Focus). Both run under the engine's protected OnClick
 // invocation, so a Lua error inside one is caught there (no crash).
 
-// Pushes _G[name]; leaves it on the stack and returns true only if it's a
-// function (otherwise pops it and returns false).
-bool PushGlobalFunc(void *L, const char *name) {
-    Game::Lua::PushString(L, name);
-    Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);
-    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_FUNCTION)
-        return true;
-    Game::Lua::SetTop(L, Game::Lua::GetTop(L) - 1);
-    return false;
-}
+// The plain global-call primitives (push-if-function, call with no/one arg)
+// live in Game::Lua now (PushGlobalFunction / CallGlobal / CallGlobalString) —
+// shared with the other modules that dispatch to FrameXML globals by name. The
+// two shapes below are specific enough to stay here.
 
-// _G[name]() -> boolean (false if the global isn't a function).
+// _G[name]() -> boolean (false if the global isn't a function). Distinct from
+// Game::Lua::CallGlobal in that it returns the call's boolean RESULT (used for
+// the IsAltKeyDown/IsShiftKeyDown modifier probes).
 bool CallBoolGlobal(void *L, const char *name) {
     const int top = Game::Lua::GetTop(L);
     bool r = false;
-    if (PushGlobalFunc(L, name)) {
+    if (Game::Lua::PushGlobalFunction(L, name)) {
         Game::Lua::Call(L, 0, 1);
         r = Game::Lua::ToBoolean(L, -1) != 0;
     }
     Game::Lua::SetTop(L, top);
     return r;
-}
-
-// _G[name]() — no args, no results.
-void CallGlobal(void *L, const char *name) {
-    const int top = Game::Lua::GetTop(L);
-    if (PushGlobalFunc(L, name))
-        Game::Lua::Call(L, 0, 0);
-    Game::Lua::SetTop(L, top);
-}
-
-// _G[name](arg) — one string arg, no results. Returns true iff the global was a
-// function and got called (false when it's absent), so callers can fall back.
-bool CallGlobalStr(void *L, const char *name, const char *arg) {
-    const int top = Game::Lua::GetTop(L);
-    const bool called = PushGlobalFunc(L, name);
-    if (called) {
-        Game::Lua::PushString(L, arg);
-        Game::Lua::Call(L, 1, 0);
-    }
-    Game::Lua::SetTop(L, top);
-    return called;
 }
 
 // _G[table][method](a, b) — two string args (null → nil, since PushString maps
@@ -357,13 +351,13 @@ void RunMacroLineC(void *L, const char *line, size_t len) {
     Game::Lua::SetTable(L, mt);
 
     // No lua_setmetatable binding — use the Lua global.
-    if (PushGlobalFunc(L, "setmetatable")) {
+    if (Game::Lua::PushGlobalFunction(L, "setmetatable")) {
         Game::Lua::PushValue(L, obj);
         Game::Lua::PushValue(L, mt);
         Game::Lua::Call(L, 2, 0);
     }
 
-    if (PushGlobalFunc(L, "ChatEdit_ParseText")) {
+    if (Game::Lua::PushGlobalFunction(L, "ChatEdit_ParseText")) {
         Game::Lua::PushValue(L, obj);
         Game::Lua::PushNumber(L, 1);           // send = 1
         Game::Lua::Call(L, 2, 0);
@@ -423,7 +417,8 @@ void MouseoverTick() {
     if (focus != nullptr) {
         auto it = g_unitByFrame.find(focus);
         if (it != g_unitByFrame.end())
-            guid = ResolveToken(it->second.c_str()); // live — follows target changes
+            guid = Unit::Identity::GuidForToken(
+                it->second.c_str()); // live — follows target changes
     }
 
     if (guid != g_lastSet) {
@@ -537,7 +532,7 @@ bool ParseBagSlot(const char *s, int *bag, int *slot) {
 // _G[name](a, b) — two number args, no results. Returns true iff called.
 bool CallGlobalNum2(void *L, const char *name, double a, double b) {
     const int top = Game::Lua::GetTop(L);
-    const bool called = PushGlobalFunc(L, name);
+    const bool called = Game::Lua::PushGlobalFunction(L, name);
     if (called) {
         Game::Lua::PushNumber(L, a);
         Game::Lua::PushNumber(L, b);
@@ -555,7 +550,7 @@ bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
         if (!unit) return false;
         // `unit="none"` clears the target (retail's SecureActionButton behavior).
         if (EqI(unit, "none")) {
-            CallGlobal(L, "ClearTarget");
+            Game::Lua::CallGlobal(L, "ClearTarget");
             return true;
         }
         // Cursor / pending-spell take precedence, matching the engine's default
@@ -564,21 +559,21 @@ bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
         // the actions are engine-only, so they go through the Lua globals (which
         // are the engine's own entries, with token→GUID resolution).
         if (Spell::AtCursor::IsPlacementActive())
-            CallGlobalStr(L, "SpellTargetUnit", unit);
+            Game::Lua::CallGlobalString(L, "SpellTargetUnit", unit);
         else if (Cursor::Info::HasItem())
-            CallGlobalStr(L, "DropItemOnUnit", unit);
+            Game::Lua::CallGlobalString(L, "DropItemOnUnit", unit);
         else
-            CallGlobalStr(L, "TargetUnit", unit);
+            Game::Lua::CallGlobalString(L, "TargetUnit", unit);
         return true;
     }
     if (EqI(verb, "assist")) {
         if (!unit) return false;
-        CallGlobalStr(L, "AssistUnit", unit);
+        Game::Lua::CallGlobalString(L, "AssistUnit", unit);
         return true;
     }
     if (EqI(verb, "focus")) {
         if (!unit) return false;
-        Unit::Focus::Set(ResolveToken(unit));
+        Unit::Focus::Set(Unit::Identity::GuidForToken(unit));
         return true;
     }
     if (EqI(verb, "spell")) {
@@ -615,19 +610,19 @@ bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
         // Prefer an addon-provided RunMacro (SuperCleveRoidMacros, pfUI, …) — it
         // handles named macros and extended macro text; fall back to the stock
         // ChatEdit_ParseText path when no RunMacro global is present.
-        if (!CallGlobalStr(L, "RunMacro", macro))
+        if (!Game::Lua::CallGlobalString(L, "RunMacro", macro))
             RunMacroTextC(L, macro);
         return true;
     }
     if (EqI(verb, "stop") || EqI(verb, "stopcasting")) {
-        CallGlobal(L, "SpellStopCasting");
+        Game::Lua::CallGlobal(L, "SpellStopCasting");
         return true;
     }
     if (EqI(verb, "menu") || EqI(verb, "togglemenu")) {
         if (!unit) return false;
         // The unit dropdown is pure FrameXML work (UnitPopup + ToggleDropDown),
         // so it lives in the !!!ClassicAPI addon; we just pop it at the cursor.
-        CallGlobalStr(L, "ClassicAPI_ToggleUnitMenu", unit);
+        Game::Lua::CallGlobalString(L, "ClassicAPI_ToggleUnitMenu", unit);
         return true;
     }
     // Unknown verb → not handled here; the chained handler runs.
@@ -770,19 +765,42 @@ void FireAttributeChanged(void *L, void *frame, const char *name) {
         return;
 
     const int savedTop = Game::Lua::GetTop(L);
+
+    // Snapshot the caller's arg1/arg2 first. SetAttribute can be called from
+    // inside a running script handler that still needs them, and the invoker
+    // below neither saves the globals nor restores the stack top — so we save
+    // (onto the stack, below anything the invoker pushes), overwrite, fire,
+    // then put them back. 1.12 passes handler args as globals, not params.
+    Game::Lua::PushString(L, "arg1");
+    Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);        // [.., oldArg1]
+    Game::Lua::PushString(L, "arg2");
+    Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);        // [.., oldArg1, oldArg2]
+    const int oldArg1 = savedTop + 1;
+    const int oldArg2 = savedTop + 2;
+
     Game::Lua::PushString(L, "arg1");
     Game::Lua::PushString(L, name);
-    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);           // _G.arg1 = name
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);          // _G.arg1 = name
     Game::Lua::PushString(L, "arg2");
     if (savedTop >= 3)
-        Game::Lua::PushValue(L, 3);
+        Game::Lua::PushValue(L, 3);                          // the new value
     else
         Game::Lua::PushNil(L);
-    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);           // _G.arg2 = value
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);          // _G.arg2 = value
 
     ++g_firingAttr;
     reinterpret_cast<InvokeAttrScript_t>(Offsets::FUN_FRAME_INVOKE_SCRIPT)(slot[0], frame);
     --g_firingAttr;
+
+    // Restore arg1/arg2 from the snapshot (the fired handler may also have
+    // written them; the caller's values win).
+    Game::Lua::PushString(L, "arg1");
+    Game::Lua::PushValue(L, oldArg1);
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);
+    Game::Lua::PushString(L, "arg2");
+    Game::Lua::PushValue(L, oldArg2);
+    Game::Lua::RawSet(L, Game::Lua::GLOBALS_INDEX);
+
     Game::Lua::SetTop(L, savedTop);
 }
 
@@ -836,10 +854,10 @@ int DoSet(void *L, bool fireHandler) { // (self, name, value)
     // is idempotent and self-healing, so calling it on every `type*` set both
     // avoids double-chaining and reinstalls after an addon clobbered our
     // OnClick — set `type*` again after re-SetScript to recover. The handler
-    // reads all the attributes fresh at click time.
-    else if ((std::strcmp(lname, "type1") == 0 || std::strcmp(lname, "type2") == 0 ||
-              std::strcmp(lname, "type") == 0) &&
-             isString) {
+    // reads all the attributes fresh at click time. IsTypeAttr covers every
+    // form the resolver reads (type, typeN, modifier-prefixed), so a middle-
+    // click or modifier-only binding still wires.
+    else if (IsTypeAttr(lname) && isString) {
         Game::Lua::PushCClosure(L, &WireOnClick, 0);
         Game::Lua::PushValue(L, 1); // arg = self
         Game::Lua::PCall(L, 1, 0, 0); // ignore errors (non-Button frame)

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -60,7 +60,10 @@
 // unit instead of switching target), `assist`, `focus`, `spell` (reads the
 // `spell` attribute and casts it on the unit via our native C_Spell.CastAtUnit —
 // the unit's GUID goes straight to the cast dispatcher, no target juggling, and
-// ground-target spells land at the unit's feet), `macro` (from the
+// ground-target spells land at the unit's feet), `item` (uses the `item`
+// attribute — a name/itemID/link via C_Item.UseItemByName with the unit as the
+// use target, or a "bag slot" string like "0 1" via UseContainerItem; the
+// deprecated `bag`/`slot` attributes also work), `macro` (from the
 // `macrotext`/`macro` attribute — prefers an addon RunMacro, else runs natively
 // via the stock ChatEdit_ParseText), `stopcasting`, `menu`/`togglemenu` (pops
 // the standard unit dropdown at the cursor via the addon's
@@ -101,6 +104,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <unordered_map>
@@ -279,6 +283,35 @@ bool CallGlobalStr(void *L, const char *name, const char *arg) {
     return called;
 }
 
+// _G[table][method](a, b) — two string args (null → nil, since PushString maps
+// NULL to nil), no results. Returns true iff the method resolved to a function
+// and got called. Used when the target is our own C_* function but the call must
+// cross the Lua boundary — e.g. C_Item.UseItemByName, whose bag walk does
+// SetTop(L, 0); going through lua_call gives it its own stack frame so that reset
+// clears only its frame, not the dispatcher's (a direct C++ call would wipe our
+// stack — the reason `spell`, which is stack-free, calls Spell::AtUnit directly
+// while `item` routes through here).
+bool CallTableFunc2Str(void *L, const char *table, const char *method,
+                       const char *a, const char *b) {
+    const int top = Game::Lua::GetTop(L);
+    bool called = false;
+    Game::Lua::PushString(L, table);
+    Game::Lua::GetTable(L, Game::Lua::GLOBALS_INDEX);   // _G[table]
+    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_TABLE) {
+        const int t = Game::Lua::GetTop(L);
+        Game::Lua::PushString(L, method);
+        Game::Lua::GetTable(L, t);                       // _G[table][method]
+        if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_FUNCTION) {
+            Game::Lua::PushString(L, a);
+            Game::Lua::PushString(L, b);
+            Game::Lua::Call(L, 2, 0);
+            called = true;
+        }
+    }
+    Game::Lua::SetTop(L, top);
+    return called;
+}
+
 // ---- macrotext execution (stock ChatEdit_ParseText, no addon dependency) ----
 //
 // 1.12 has no `RunMacroText`/`RunMacro` global — those are addon shims (pfUI
@@ -449,6 +482,71 @@ bool ReadModAttr(void *L, int fi, const char *prefix, const char *name,
     return CopyAttr(L, fi, key, buf, n);
 }
 
+// Reads attribute `keyLower` as an int (stored as a number, or a numeric
+// string) into *out. Leaves the stack as it found it. Returns true on success.
+bool ReadAttrInt(void *L, int fi, const char *keyLower, int *out) {
+    bool ok = false;
+    if (TryPushValue(L, fi, keyLower)) {                 // value left on top
+        const int t = Game::Lua::Type(L, -1);
+        if (t == Game::Lua::TYPE_NUMBER) {
+            *out = static_cast<int>(Game::Lua::ToNumber(L, -1));
+            ok = true;
+        } else if (t == Game::Lua::TYPE_STRING) {
+            const char *s = Game::Lua::ToString(L, -1);
+            char *end = nullptr;
+            const long v = s ? std::strtol(s, &end, 10) : 0;
+            if (s && end != s) {
+                *out = static_cast<int>(v);
+                ok = true;
+            }
+        }
+        Game::Lua::SetTop(L, Game::Lua::GetTop(L) - 1);  // pop the peeked value
+    }
+    return ok;
+}
+
+// Numeric analog of ReadModAttr (prefix..name..suffix precedence).
+bool ReadModAttrInt(void *L, int fi, const char *prefix, const char *name,
+                    const char *suffix, int *out) {
+    char key[128];
+    Compose3Lower(key, sizeof key, prefix, name, suffix);
+    if (ReadAttrInt(L, fi, key, out)) return true;
+    Compose3Lower(key, sizeof key, "", name, suffix);
+    if (ReadAttrInt(L, fi, key, out)) return true;
+    Compose3Lower(key, sizeof key, "", name, "");
+    return ReadAttrInt(L, fi, key, out);
+}
+
+// Parses a "bag slot" string (two integers, e.g. "0 1") into bag/slot. Returns
+// false unless the whole string is exactly two integers, so a normal item name
+// or a bare itemID ("12345") falls through to the name path.
+bool ParseBagSlot(const char *s, int *bag, int *slot) {
+    char *end = nullptr;
+    const long b = std::strtol(s, &end, 10);
+    if (end == s) return false;                          // not a leading number
+    const char *p = end;
+    const long sl = std::strtol(p, &end, 10);
+    if (end == p) return false;                          // only one number
+    while (*end == ' ' || *end == '\t') ++end;
+    if (*end != '\0') return false;                      // trailing junk
+    *bag = static_cast<int>(b);
+    *slot = static_cast<int>(sl);
+    return true;
+}
+
+// _G[name](a, b) — two number args, no results. Returns true iff called.
+bool CallGlobalNum2(void *L, const char *name, double a, double b) {
+    const int top = Game::Lua::GetTop(L);
+    const bool called = PushGlobalFunc(L, name);
+    if (called) {
+        Game::Lua::PushNumber(L, a);
+        Game::Lua::PushNumber(L, b);
+        Game::Lua::Call(L, 2, 0);
+    }
+    Game::Lua::SetTop(L, top);
+    return called;
+}
+
 // Performs the resolved `verb` on `unit` (a token attribute value, may be null).
 // Returns true if it owned the click (so the chained handler is skipped).
 bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
@@ -485,6 +583,24 @@ bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
             return false;
         Spell::AtUnit::CastByName(spell, unit);
         return true;
+    }
+    if (EqI(verb, "item")) {
+        char item[128];
+        int bag, slot;
+        if (ReadModAttr(L, fi, prefix, "item", suffix, item, sizeof item)) {
+            if (ParseBagSlot(item, &bag, &slot))
+                CallGlobalNum2(L, "UseContainerItem", bag, slot);
+            else
+                CallTableFunc2Str(L, "C_Item", "UseItemByName", item, unit);
+            return true;
+        }
+        // Deprecated form: no `item`, take the `bag` + `slot` attributes.
+        if (ReadModAttrInt(L, fi, prefix, "bag", suffix, &bag) &&
+            ReadModAttrInt(L, fi, prefix, "slot", suffix, &slot)) {
+            CallGlobalNum2(L, "UseContainerItem", bag, slot);
+            return true;
+        }
+        return false;
     }
     if (EqI(verb, "macro")) {
         char macro[512];

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -553,6 +553,11 @@ bool DispatchVerb(void *L, int fi, const char *prefix, const char *suffix,
                   const char *verb, const char *unit) {
     if (EqI(verb, "target")) {
         if (!unit) return false;
+        // `unit="none"` clears the target (retail's SecureActionButton behavior).
+        if (EqI(unit, "none")) {
+            CallGlobal(L, "ClearTarget");
+            return true;
+        }
         // Cursor / pending-spell take precedence, matching the engine's default
         // unit interaction — cast the pending spell / drop the item on the unit
         // instead of switching target. The two predicates are ours (direct C++);

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -19,8 +19,9 @@
 // system at all — it arrived in 2.0 with secure frames. Attributes are just a
 // per-frame, case-insensitive key→value store (verified from the 3.3.5
 // implementation: a name→Lua-value map plus a getter with prefix/name/suffix
-// wildcard precedence). We store the map on the frame's own Lua table under a
-// private key, so it's collected with the frame.
+// wildcard precedence). We store the map in the Lua registry keyed by the frame
+// (registry[frame]) — invisible to Lua script and tamper-proof, like retail's
+// C-side attribute store (see PushSub).
 //
 // The headline use — SecureUnitButton behavior, minus the secure wrapper (1.12
 // has no combat lockdown or taint, so protected actions just work):
@@ -114,11 +115,6 @@ int CallScript(uintptr_t fn, void *L) {
     return reinterpret_cast<ScriptFn_t>(fn)(L);
 }
 
-// Private key on the frame's own Lua table for the attribute subtable. The
-// leading control byte can't be produced by a lowercased user attribute name,
-// so it never collides with a real attribute.
-constexpr const char kAttrKey[] = "\1ClassicAPIAttributes";
-
 // ---- small string helpers --------------------------------------------------
 
 void LowerCopy(char *dst, const char *src, size_t n) {
@@ -155,30 +151,28 @@ bool EqI(const char *a, const char *b) {
     return *a == *b;
 }
 
-// ---- attribute storage (on the frame's own Lua table) ----------------------
+// ---- attribute storage (in the Lua registry, keyed by the frame) -----------
 
-// Pushes frame[kAttrKey] (the attribute subtable) onto the stack. With
-// create=true, lazily creates and stores it. Returns true iff a subtable is
-// left on top; false (nothing left on the stack) when absent and !create.
+// Pushes the frame's attribute subtable onto the stack. Stored as
+// registry[frame] in the Lua registry (LUA_REGISTRYINDEX) rather than as a
+// field on the frame's own table — the registry is C-side and has no _G path,
+// so the store is invisible to `pairs(frame)` and can't be read or tampered
+// with from Lua, matching how retail keeps attributes C-side. With create=true,
+// lazily creates and stores it. Returns true iff a subtable is left on top;
+// false (nothing left on the stack) when absent and !create. 1.12 frames are
+// immortal, so the strong registry key never leaks.
 bool PushSub(void *L, int frameIdx, bool create) {
-    Game::Lua::PushValue(L, frameIdx);      // [.., frame]
-    const int f = Game::Lua::GetTop(L);
-    Game::Lua::PushString(L, kAttrKey);      // [.., frame, key]
-    Game::Lua::RawGet(L, f);                 // [.., frame, sub|nil]
-    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_TABLE) {
-        Game::Lua::Remove(L, f);             // [.., sub]
-        return true;
-    }
-    Game::Lua::SetTop(L, f);                 // [.., frame]   (drop the nil)
-    if (!create) {
-        Game::Lua::SetTop(L, f - 1);         // [..]          (drop frame)
+    Game::Lua::PushValue(L, frameIdx);                  // [.., frame]  (key)
+    Game::Lua::RawGet(L, Game::Lua::REGISTRY_INDEX);    // [.., sub|nil]
+    if (Game::Lua::Type(L, -1) == Game::Lua::TYPE_TABLE)
+        return true;                                    // [.., sub]
+    Game::Lua::SetTop(L, Game::Lua::GetTop(L) - 1);     // drop the nil -> [..]
+    if (!create)
         return false;
-    }
-    Game::Lua::NewTable(L);                   // [.., frame, sub]
-    Game::Lua::PushString(L, kAttrKey);       // [.., frame, sub, key]
-    Game::Lua::PushValue(L, f + 1);           // [.., frame, sub, key, sub]
-    Game::Lua::RawSet(L, f);                  // frame[key] = sub -> [.., frame, sub]
-    Game::Lua::Remove(L, f);                  // [.., sub]
+    Game::Lua::NewTable(L);                             // [.., sub]
+    Game::Lua::PushValue(L, frameIdx);                  // [.., sub, frame]  (key)
+    Game::Lua::PushValue(L, -2);                        // [.., sub, frame, sub]  (value)
+    Game::Lua::RawSet(L, Game::Lua::REGISTRY_INDEX);    // registry[frame] = sub -> [.., sub]
     return true;
 }
 
@@ -204,8 +198,9 @@ bool CopyAttr(void *L, int frameIdx, const char *lname, char *buf, size_t n) {
     return ok;
 }
 
-// If frame[kAttrKey][keyLower] is non-nil, leave that value on the stack top
-// and return true; otherwise restore the stack and return false.
+// If the frame's attribute subtable has a non-nil value for keyLower, leave that
+// value on the stack top and return true; otherwise restore the stack and
+// return false.
 bool TryPushValue(void *L, int frameIdx, const char *keyLower) {
     const int top = Game::Lua::GetTop(L);
     if (PushSub(L, frameIdx, false)) {       // [.., sub]

--- a/src/frame/Attributes.cpp
+++ b/src/frame/Attributes.cpp
@@ -14,7 +14,7 @@
 // Frame attributes + unit-frame mouseover/click backport.
 //
 // Backports `frame:SetAttribute` / `frame:SetAttributeNoHandler` /
-// `frame:GetAttribute` to 1.12 as native methods on the base Frame registry
+// `frame:ClearAttribute` / `frame:GetAttribute` to 1.12 as native methods on the base Frame registry
 // (every frame gets them, like the modern clients). Vanilla has no attribute
 // system at all — it arrived in 2.0 with secure frames. Attributes are just a
 // per-frame, case-insensitive key→value store (verified from the 3.3.5
@@ -737,6 +737,31 @@ int DoSet(void *L, bool fireHandler) { // (self, name, value)
 int __fastcall Script_SetAttribute(void *L) { return DoSet(L, /*fireHandler*/ true); }
 int __fastcall Script_SetAttributeNoHandler(void *L) { return DoSet(L, /*fireHandler*/ false); }
 
+// `cleared = frame:ClearAttribute("name")` — retail (11.2.0) attribute removal;
+// `cleared` is true iff the attribute was set (and is now gone). Routes through
+// DoSet's nil-value path so it also drops a `unit` mouseover binding, but does
+// NOT fire OnAttributeChanged — verified against retail (a live 12.0 test showed
+// ClearAttribute firing no handler, unlike SetAttribute).
+int __fastcall Script_ClearAttribute(void *L) {
+    if (!Game::Lua::IsString(L, 2)) {
+        Game::Lua::Error(L, "Usage: frame:ClearAttribute(\"name\")");
+        return 0;
+    }
+    char lname[256];
+    LowerCopy(lname, Game::Lua::ToString(L, 2), sizeof lname);
+
+    const bool existed = TryPushValue(L, 1, lname); // leaves the value on top if set
+    if (existed)
+        Game::Lua::SetTop(L, Game::Lua::GetTop(L) - 1); // drop the peeked value
+
+    Game::Lua::SetTop(L, 2);   // (self, name)
+    Game::Lua::PushNil(L);     // (self, name, nil) → value = nil clears the key
+    DoSet(L, /*fireHandler*/ false); // retail ClearAttribute fires no OnAttributeChanged
+
+    Game::Lua::PushBool(L, existed);
+    return 1;
+}
+
 int __fastcall Script_GetAttribute(void *L) {
     if (!Game::Lua::IsString(L, 2)) {
         Game::Lua::Error(L, "Usage: frame:GetAttribute(\"name\")");
@@ -775,6 +800,7 @@ int __fastcall Script_GetAttribute(void *L) {
 const Game::Lua::FrameMethodEntry g_frameMethods[] = {
     {"SetAttribute", &Script_SetAttribute},
     {"SetAttributeNoHandler", &Script_SetAttributeNoHandler},
+    {"ClearAttribute", &Script_ClearAttribute},
     {"GetAttribute", &Script_GetAttribute},
 };
 

--- a/src/frame/ScriptArgs.cpp
+++ b/src/frame/ScriptArgs.cpp
@@ -57,7 +57,7 @@ namespace {
 
 // Runtime switch. Default ON. When false, both detours tail-call the original
 // runner unchanged (exact vanilla behavior, no reimplementation risk).
-bool g_enabled = true;
+bool g_enabled = false;
 
 // Engine cap: the runner stops setting arg globals at index 19 (arg1..arg19).
 constexpr int kMaxArgs = 19;

--- a/src/frame/ScriptArgs.cpp
+++ b/src/frame/ScriptArgs.cpp
@@ -40,11 +40,11 @@
 // SetScript creates a distinct ref, so a function bound to two scripts still
 // differs per slot — so no fragile "are we mid event-dispatch" flag is needed.
 //
-// Runtime switch (default ON): `SetModernScriptArgs(false)` / (true),
-// `GetModernScriptArgs()`. While disabled the hook is a straight passthrough
-// to the original runner (zero reimplementation risk), so it can be toggled
-// safely per session — worth knowing, since this lands on the hottest Lua path
-// in the engine (FUN_FRAME_RUN_SCRIPT_ARGS fires for every OnUpdate frame).
+// Runtime switch, default OFF (opt-in): `SetModernScriptArgs(true)` enables it,
+// `GetModernScriptArgs()` reads the state. While disabled both detours are a
+// straight passthrough to the original runner (zero reimplementation risk).
+// Opt-in because this lands on the hottest Lua path in the engine
+// (FUN_FRAME_RUN_SCRIPT_ARGS fires for every OnUpdate frame).
 
 #include "Game.h"
 #include "Offsets.h"
@@ -55,8 +55,8 @@ namespace Frame::ScriptArgs {
 
 namespace {
 
-// Runtime switch. Default ON. When false, both detours tail-call the original
-// runner unchanged (exact vanilla behavior, no reimplementation risk).
+// Runtime switch. Default OFF (opt-in). When false, both detours tail-call the
+// original runner unchanged (exact vanilla behavior, no reimplementation risk).
 bool g_enabled = false;
 
 // Engine cap: the runner stops setting arg globals at index 19 (arg1..arg19).

--- a/src/frame/ScriptArgs.cpp
+++ b/src/frame/ScriptArgs.cpp
@@ -1,0 +1,295 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+// Modern positional script arguments — make every frame-script handler
+// receive `(self, arg1..argN)` the way later clients do, on top of the
+// vanilla `this`/`arg1`/`event` globals.
+//
+//   frame:SetScript("OnMouseWheel", function()            print(this, arg1) end)  -- vanilla
+//   frame:SetScript("OnMouseWheel", function(self, delta)  print(self, delta) end)  -- modern
+//
+// Vanilla ALWAYS invokes a script handler with ZERO Lua arguments: the two
+// runners the engine funnels every dispatch through — FUN_FRAME_INVOKE_SCRIPT
+// (no-arg scripts) and FUN_FRAME_RUN_SCRIPT_ARGS (scripts with values) — set
+// the `this`/`arg1..argN` globals and then `lua_pcall(handler, /*nargs*/0)`.
+// So `function(self, delta)` gets nothing today.
+//
+// We co-hook both runners and REPLACE their pcall tail: keep setting the same
+// globals (so vanilla handlers reading `this`/`arg1` keep working — this is
+// purely additive; Lua silently drops the extra positional args a zero-param
+// handler doesn't declare), but push `self` + `arg1..argN` as real arguments
+// and `pcall` with `nargs = 1 + N`. The reimplementation mirrors the engine's
+// exact global save/set/restore and its message-handler errfunc; only the
+// final push+pcall differs.
+//
+// Convention: `(self, arg1..argN)` for every script, plus `event` inserted as
+// the first positional for OnEvent — `(self, event, arg1..argN)` — matching
+// retail (and Frame::Modern's HookScript). An OnEvent dispatch is detected
+// structurally at the runner: the handler ref being invoked equals the frame's
+// OnEvent slot handler (frame+OFF_FRAME_ONEVENT_SLOT). This is exact — each
+// SetScript creates a distinct ref, so a function bound to two scripts still
+// differs per slot — so no fragile "are we mid event-dispatch" flag is needed.
+//
+// Runtime switch (default ON): `SetModernScriptArgs(false)` / (true),
+// `GetModernScriptArgs()`. While disabled the hook is a straight passthrough
+// to the original runner (zero reimplementation risk), so it can be toggled
+// safely per session — worth knowing, since this lands on the hottest Lua path
+// in the engine (FUN_FRAME_RUN_SCRIPT_ARGS fires for every OnUpdate frame).
+
+#include "Game.h"
+#include "Offsets.h"
+
+#include <cstdint>
+
+namespace Frame::ScriptArgs {
+
+namespace {
+
+// Runtime switch. Default ON. When false, both detours tail-call the original
+// runner unchanged (exact vanilla behavior, no reimplementation risk).
+bool g_enabled = true;
+
+// Engine cap: the runner stops setting arg globals at index 19 (arg1..arg19).
+constexpr int kMaxArgs = 19;
+
+// --- raw engine primitives not exposed via Game::Lua -----------------------
+// lua_rawgeti(L, idx, n) — push table_at_idx[n]. Used with idx = REGISTRY to
+// push a value stored under an integer ref (handler / frame object / message
+// handler / luaL_ref'd saved globals).
+using RawGetI_t = void(__fastcall *)(void *L, int idx, int ref);
+// luaL_ref(L, t) → int — pop the top, store it under a fresh int key in table
+// `t`, return the key. luaL_unref frees it.
+using LuaLRef_t = int(__fastcall *)(void *L, int t);
+using LuaLUnref_t = void(__fastcall *)(void *L, int t, int ref);
+// FUN_FRAMESCRIPT_OBJECT_SCRIPT_REGISTER — __thiscall(frame, nameOrNull);
+// lazily materializes the frame's Lua-registry ref at frame+OFF_COBJECT_LUA_REF.
+using ScriptRegister_t = void(__thiscall *)(void *frame, void *nameOrNull);
+
+const auto RawGetI = reinterpret_cast<RawGetI_t>(Offsets::LUA_RAWGETI);
+const auto LuaLRef = reinterpret_cast<LuaLRef_t>(Offsets::LUA_REF_REF);
+const auto LuaLUnref = reinterpret_cast<LuaLUnref_t>(Offsets::LUA_REF_UNREF);
+
+// Returns the frame's Lua object ref (frame+0x08), lazily creating it exactly
+// as the engine runner does (`if (refcount == 0) ScriptRegister(frame, 0)`).
+int EnsureLuaRef(void *frame) {
+    auto *f = reinterpret_cast<uint8_t *>(frame);
+    if (*reinterpret_cast<int *>(f + Offsets::OFF_COBJECT_LUA_REFCOUNT) == 0)
+        reinterpret_cast<ScriptRegister_t>(
+            Offsets::FUN_FRAMESCRIPT_OBJECT_SCRIPT_REGISTER)(frame, nullptr);
+    return *reinterpret_cast<int *>(f + Offsets::OFF_COBJECT_LUA_REF);
+}
+
+// Writes "arg" + k (k in 1..19) into buf; buf must hold at least 6 bytes.
+void ArgName(char *buf, int k) {
+    buf[0] = 'a';
+    buf[1] = 'r';
+    buf[2] = 'g';
+    if (k < 10) {
+        buf[3] = static_cast<char>('0' + k);
+        buf[4] = '\0';
+    } else {
+        buf[3] = static_cast<char>('0' + k / 10);
+        buf[4] = static_cast<char>('0' + k % 10);
+        buf[5] = '\0';
+    }
+}
+
+// Sets _G[name] = <value currently on the stack top>, capturing the previous
+// _G[name] into *outOldRef (a luaL_ref for later restore). Stack-neutral:
+// consumes the value, leaves the stack as it was minus that value.
+void SetGlobalSaving(void *L, const char *name, int *outOldRef) {
+    using namespace Game::Lua;
+    PushString(L, name);        // [.., newVal, name]
+    GetTable(L, GLOBALS_INDEX); // [.., newVal, oldVal]
+    *outOldRef = LuaLRef(L, REGISTRY_INDEX); // [.., newVal]
+    PushString(L, name);        // [.., newVal, name]
+    Insert(L, -2);              // [.., name, newVal]
+    SetTable(L, GLOBALS_INDEX); // [..]
+}
+
+// Restores _G[name] to the value at oldRef, then frees the ref.
+void RestoreGlobal(void *L, const char *name, int oldRef) {
+    using namespace Game::Lua;
+    RawGetI(L, REGISTRY_INDEX, oldRef); // [.., oldVal]
+    PushString(L, name);                // [.., oldVal, name]
+    Insert(L, -2);                      // [.., name, oldVal]
+    SetTable(L, GLOBALS_INDEX);         // [..]
+    LuaLUnref(L, REGISTRY_INDEX, oldRef);
+}
+
+// Reimplements the runner tail: set globals (with save/restore), then invoke
+// the handler with modern positional args `(self, arg1..argN)` under the
+// engine's own message-handler errfunc. `fmt`/`vaPtr` are null for the no-arg
+// runner (N == 0).
+void RunModern(int handlerRef, void *frame, const char *fmt, const void *vaPtr) {
+    using namespace Game::Lua;
+    void *L = State();
+    if (L == nullptr)
+        return;
+
+    // --- _G.this = frame -----------------------------------------------------
+    const bool haveThis = frame != nullptr;
+    // OnEvent dispatch? The event dispatchers invoke the frame's OnEvent slot
+    // (frame+0x0C); matching the handler ref against that slot identifies it
+    // exactly. When so, `event` (a global the dispatcher has set) is prepended
+    // as the first positional to mirror retail's (self, event, arg1..argN).
+    const bool isOnEvent =
+        haveThis &&
+        *reinterpret_cast<const int *>(reinterpret_cast<uint8_t *>(frame) +
+                                       Offsets::OFF_FRAME_ONEVENT_SLOT) ==
+            handlerRef;
+    int selfRef = 0;
+    int oldThisRef = 0;
+    if (haveThis) {
+        selfRef = EnsureLuaRef(frame);
+        RawGetI(L, REGISTRY_INDEX, selfRef); // push frame object
+        SetGlobalSaving(L, "this", &oldThisRef);
+    }
+
+    // --- _G.arg1..argN from the format --------------------------------------
+    int oldArgRefs[kMaxArgs];
+    char argNames[kMaxArgs][6];
+    int n = 0;
+    if (fmt != nullptr) {
+        const char *cur = static_cast<const char *>(vaPtr);
+        for (const char *p = fmt; *p != '\0' && n < kMaxArgs; ++p) {
+            if (*p != '%')
+                continue;
+            ++p;
+            if (*p == '\0')
+                break;
+            bool consumed = true;
+            switch (*p) {
+            case 'd':
+                PushNumber(L, static_cast<double>(*reinterpret_cast<const int *>(cur)));
+                cur += 4;
+                break;
+            case 'u':
+                PushNumber(L, static_cast<double>(
+                                  *reinterpret_cast<const unsigned int *>(cur)));
+                cur += 4;
+                break;
+            case 'f':
+                PushNumber(L, *reinterpret_cast<const double *>(cur));
+                cur += 8;
+                break;
+            case 's':
+                PushString(L, *reinterpret_cast<const char *const *>(cur));
+                cur += 4;
+                break;
+            default:
+                consumed = false; // unknown spec — skip, consume nothing
+                break;
+            }
+            if (!consumed)
+                continue;
+            ArgName(argNames[n], n + 1);
+            SetGlobalSaving(L, argNames[n], &oldArgRefs[n]);
+            ++n;
+        }
+    }
+
+    // --- call handler(self, arg1..argN) -------------------------------------
+    const int base = GetTop(L);
+    const int errRef = *reinterpret_cast<const int *>(
+        static_cast<uintptr_t>(Offsets::VAR_FRAMESCRIPT_ERROR_HANDLER_REF));
+    int errIdx = 0;
+    if (errRef > 0) {
+        RawGetI(L, REGISTRY_INDEX, errRef); // message handler
+        errIdx = base + 1;                  // absolute index of the errfunc
+    }
+    RawGetI(L, REGISTRY_INDEX, handlerRef); // handler
+    if (haveThis)
+        RawGetI(L, REGISTRY_INDEX, selfRef); // self
+    else
+        PushNil(L);
+    if (isOnEvent) { // event goes before the args, retail-style
+        PushString(L, "event");
+        GetTable(L, GLOBALS_INDEX);
+    }
+    for (int k = 0; k < n; ++k) { // positional args, re-read from the globals
+        PushString(L, argNames[k]);
+        GetTable(L, GLOBALS_INDEX);
+    }
+    PCall(L, 1 + (isOnEvent ? 1 : 0) + n, 0, errIdx);
+    SetTop(L, base); // drop the message handler + any leftover error object
+
+    // --- restore globals (reverse order) ------------------------------------
+    for (int k = n - 1; k >= 0; --k)
+        RestoreGlobal(L, argNames[k], oldArgRefs[k]);
+    if (haveThis)
+        RestoreGlobal(L, "this", oldThisRef);
+}
+
+// --- FUN_FRAME_RUN_SCRIPT_ARGS co-hook (scripts with values) ----------------
+using RunArgs_t = void(__cdecl *)(int handlerRef, void *frame, const char *fmt,
+                                  const void *vaPtr);
+RunArgs_t g_origRunArgs = nullptr;
+
+void __cdecl RunArgs_h(int handlerRef, void *frame, const char *fmt,
+                       const void *vaPtr) {
+    if (!g_enabled || handlerRef == 0 || fmt == nullptr) {
+        g_origRunArgs(handlerRef, frame, fmt, vaPtr);
+        return;
+    }
+    RunModern(handlerRef, frame, fmt, vaPtr);
+}
+
+// --- FUN_FRAME_INVOKE_SCRIPT co-hook (no-arg scripts) -----------------------
+// Same address Tooltip::SetEvents calls directly to fire OnTooltipSet*; with
+// the switch enabled those fire with (self) too, which is the modern shape.
+using Invoke_t = void(__fastcall *)(int handlerRef, void *frame);
+Invoke_t g_origInvoke = nullptr;
+
+void __fastcall Invoke_h(int handlerRef, void *frame) {
+    if (!g_enabled || handlerRef == 0 || frame == nullptr) {
+        g_origInvoke(handlerRef, frame);
+        return;
+    }
+    RunModern(handlerRef, frame, /*fmt*/ nullptr, /*vaPtr*/ nullptr);
+}
+
+const Game::HookAutoRegister _runArgsHook{
+    Offsets::FUN_FRAME_RUN_SCRIPT_ARGS,
+    reinterpret_cast<void *>(&RunArgs_h),
+    reinterpret_cast<void **>(&g_origRunArgs)};
+
+const Game::HookAutoRegister _invokeHook{
+    Offsets::FUN_FRAME_INVOKE_SCRIPT,
+    reinterpret_cast<void *>(&Invoke_h),
+    reinterpret_cast<void **>(&g_origInvoke)};
+
+// --- Lua toggle -------------------------------------------------------------
+int __fastcall Script_SetModernScriptArgs(void *L) {
+    g_enabled = Game::Lua::ToBoolean(L, 1) != 0;
+    Game::Lua::PushBool(L, g_enabled);
+    return 1;
+}
+
+int __fastcall Script_GetModernScriptArgs(void *L) {
+    Game::Lua::PushBool(L, g_enabled);
+    return 1;
+}
+
+void RegisterLuaFunctions() {
+    Game::Lua::RegisterGlobalFunction("SetModernScriptArgs",
+                                      &Script_SetModernScriptArgs);
+    Game::Lua::RegisterGlobalFunction("GetModernScriptArgs",
+                                      &Script_GetModernScriptArgs);
+}
+
+const Game::ModuleAutoRegister _autoreg{&RegisterLuaFunctions};
+
+} // namespace
+
+} // namespace Frame::ScriptArgs

--- a/src/lossofcontrol/Info.cpp
+++ b/src/lossofcontrol/Info.cpp
@@ -43,6 +43,7 @@
 #include "aura/Source.h"
 #include "dbc/Lookup.h"
 #include "event/Custom.h"
+#include "net/PacketDispatch.h"
 #include "net/PacketReader.h"
 #include "spell/Lookup.h"
 #include "tick/WorldTick.h"
@@ -111,7 +112,7 @@ const char *ClassifyControlLoss(const uint8_t *rec) {
     return nullptr;
 }
 
-// ---- School-interrupt lockout state (fed by the SMSG_SPELL_COOLDOWN hook) --
+// ---- School-interrupt lockout state (fed by SMSG_SPELL_COOLDOWN) -----------
 
 // One active lockout per school index (0..6); active while now < endMs.
 // Self-expiring, per-process — a stale entry from before a relog is already
@@ -122,54 +123,51 @@ struct SchoolLock {
 };
 SchoolLock g_schoolLock[Offsets::SPELL_SCHOOL_COUNT] = {};
 
-using CooldownHandler_t = int(__stdcall *)(uint32_t *opCode,
-                                           Net::CDataStore *packet);
-CooldownHandler_t g_origCooldown = nullptr;
-
-int __stdcall Cooldown_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint64_t guid = Net::Read<uint64_t>(packet);
-        if (guid != 0 && guid == Unit::Identity::PlayerGuid()) {
-            int count = 0;
-            int firstDur = 0;
-            bool uniform = true;
-            int schoolIdx = -1;
-            while (packet->m_read + 8 <= packet->m_size && count < 256) {
-                const uint32_t spellID = Net::Read<uint32_t>(packet);
-                const int dur = static_cast<int>(Net::Read<uint32_t>(packet));
-                if (count == 0)
-                    firstDur = dur;
-                else if (dur != firstDur)
-                    uniform = false;
-                if (schoolIdx < 0) {
-                    const uint8_t *rec =
-                        Spell::Lookup::RecordForID(static_cast<int>(spellID));
-                    if (rec != nullptr) {
-                        const int s = SpellSchoolIndex(rec);
-                        if (s >= 0 && s < Offsets::SPELL_SCHOOL_COUNT)
-                            schoolIdx = s;
-                    }
-                }
-                ++count;
-            }
-            // A uniform-duration batch of >=2 same-school spells is a school
-            // lockout (ProhibitSpellSchool); single/varied packets are normal
-            // cooldowns and ignored.
-            if (count >= 2 && uniform && firstDur > 0 && schoolIdx >= 0) {
-                const int now = NowMs();
-                g_schoolLock[schoolIdx].startMs = now;
-                g_schoolLock[schoolIdx].endMs = now + firstDur;
+// Subscribe to the SMSG dispatch funnel rather than co-hooking the cooldown
+// handler (0x006E9460) directly — nampower detours that leaf handler, so
+// sharing its prologue is the documented MinHook/hadesmem collision risk;
+// the funnel is a chokepoint nobody else hooks. The dispatcher positions the
+// cursor at the body (after the u16 opcode) and restores it afterward, so we
+// just read.
+void CooldownSub(uint32_t opcode, Net::CDataStore *packet) {
+    if (opcode != Offsets::SMSG_SPELL_COOLDOWN || packet == nullptr)
+        return;
+    const uint64_t guid = Net::Read<uint64_t>(packet);
+    if (guid == 0 || guid != Unit::Identity::PlayerGuid())
+        return;
+    int count = 0;
+    int firstDur = 0;
+    bool uniform = true;
+    int schoolIdx = -1;
+    while (packet->m_read + 8 <= packet->m_size && count < 256) {
+        const uint32_t spellID = Net::Read<uint32_t>(packet);
+        const int dur = static_cast<int>(Net::Read<uint32_t>(packet));
+        if (count == 0)
+            firstDur = dur;
+        else if (dur != firstDur)
+            uniform = false;
+        if (schoolIdx < 0) {
+            const uint8_t *rec =
+                Spell::Lookup::RecordForID(static_cast<int>(spellID));
+            if (rec != nullptr) {
+                const int s = SpellSchoolIndex(rec);
+                if (s >= 0 && s < Offsets::SPELL_SCHOOL_COUNT)
+                    schoolIdx = s;
             }
         }
-        packet->m_read = saved; // restore before the engine re-parses
+        ++count;
     }
-    return g_origCooldown(opCode, packet);
+    // A uniform-duration batch of >=2 same-school spells is a school lockout
+    // (ProhibitSpellSchool); single/varied packets are normal cooldowns and
+    // ignored.
+    if (count >= 2 && uniform && firstDur > 0 && schoolIdx >= 0) {
+        const int now = NowMs();
+        g_schoolLock[schoolIdx].startMs = now;
+        g_schoolLock[schoolIdx].endMs = now + firstDur;
+    }
 }
 
-const Game::HookAutoRegister _cooldownHook{
-    Offsets::FUN_SPELL_COOLDOWN_HANDLER, reinterpret_cast<void *>(&Cooldown_h),
-    reinterpret_cast<void **>(&g_origCooldown)};
+const Net::PacketDispatch::AutoSubscribe _cooldownSub{&CooldownSub};
 
 // ---- Aggregated active-effect list ----------------------------------------
 

--- a/src/net/PacketDispatch.cpp
+++ b/src/net/PacketDispatch.cpp
@@ -22,7 +22,7 @@ namespace Net::PacketDispatch {
 
 namespace {
 
-AutoSubscribe *g_head = nullptr;
+PacketSubscriber *g_head = nullptr;
 
 // `FUN_NET_MESSAGE_DISPATCH` — `__thiscall(netClient, param_1, CDataStore*)`,
 // rendered here as `__fastcall(self /*ecx*/, edx, param_1, packet)`. The
@@ -36,23 +36,15 @@ Dispatch_t g_orig = nullptr;
 
 void __fastcall Dispatch_h(void *self, void *edx, uint32_t param_1,
                            CDataStore *packet) {
-    if (packet != nullptr && g_head != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint32_t opcode = Net::Read<uint16_t>(packet);
-        const uint32_t afterOpcode = packet->m_read;
-        for (auto *node = g_head; node != nullptr; node = node->next) {
-            packet->m_read = afterOpcode; // each subscriber reads independently
-            node->cb(opcode, packet);
-        }
-        packet->m_read = saved; // hand the engine an untouched cursor
-    }
+    if (packet != nullptr && g_head != nullptr)
+        Net::FanOutByOpcode<uint16_t>(g_head, packet); // opcode is a u16 SMSG id
     g_orig(self, edx, param_1, packet);
 }
 
 } // namespace
 
-AutoSubscribe::AutoSubscribe(Callback cb) : cb(cb), next(g_head) {
-    g_head = this;
+AutoSubscribe::AutoSubscribe(Net::PacketCallback cb) {
+    Net::Subscribe(g_head, this, cb);
 }
 
 static const Game::HookAutoRegister _hook{

--- a/src/net/PacketDispatch.cpp
+++ b/src/net/PacketDispatch.cpp
@@ -1,0 +1,63 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#include "PacketDispatch.h"
+
+#include "Game.h"
+#include "Offsets.h"
+
+#include <cstdint>
+
+namespace Net::PacketDispatch {
+
+namespace {
+
+AutoSubscribe *g_head = nullptr;
+
+// `FUN_NET_MESSAGE_DISPATCH` — `__thiscall(netClient, param_1, CDataStore*)`,
+// rendered here as `__fastcall(self /*ecx*/, edx, param_1, packet)`. The
+// engine reads the leading u16 opcode from the packet, then dispatches to
+// `netClient->handlers[opcode]`. We peek the same u16, fan out to subscribers
+// with the cursor at the body, restore the cursor, and let the original run —
+// so the engine (and any leaf-handler hooks) see an untouched packet.
+using Dispatch_t = void(__fastcall *)(void *self, void *edx, uint32_t param_1,
+                                      CDataStore *packet);
+Dispatch_t g_orig = nullptr;
+
+void __fastcall Dispatch_h(void *self, void *edx, uint32_t param_1,
+                           CDataStore *packet) {
+    if (packet != nullptr && g_head != nullptr) {
+        const uint32_t saved = packet->m_read;
+        const uint32_t opcode = Net::Read<uint16_t>(packet);
+        const uint32_t afterOpcode = packet->m_read;
+        for (auto *node = g_head; node != nullptr; node = node->next) {
+            packet->m_read = afterOpcode; // each subscriber reads independently
+            node->cb(opcode, packet);
+        }
+        packet->m_read = saved; // hand the engine an untouched cursor
+    }
+    g_orig(self, edx, param_1, packet);
+}
+
+} // namespace
+
+AutoSubscribe::AutoSubscribe(Callback cb) : cb(cb), next(g_head) {
+    g_head = this;
+}
+
+static const Game::HookAutoRegister _hook{
+    Offsets::FUN_NET_MESSAGE_DISPATCH,
+    reinterpret_cast<void *>(&Dispatch_h),
+    reinterpret_cast<void **>(&g_orig)};
+
+} // namespace Net::PacketDispatch

--- a/src/net/PacketDispatch.h
+++ b/src/net/PacketDispatch.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "net/PacketObserver.h"
 #include "net/PacketReader.h"
 
 #include <cstdint>
@@ -39,12 +40,11 @@
 
 namespace Net::PacketDispatch {
 
-using Callback = void (*)(uint32_t opcode, CDataStore *packet);
-
-struct AutoSubscribe {
-    explicit AutoSubscribe(Callback cb);
-    Callback cb;
-    AutoSubscribe *next;
+// Chains onto the incoming-packet subscriber list at static-init time. The
+// list plumbing + fan-out live in net/PacketObserver.h (shared with
+// Net::SendObserver).
+struct AutoSubscribe : Net::PacketSubscriber {
+    explicit AutoSubscribe(Net::PacketCallback cb);
 };
 
 } // namespace Net::PacketDispatch

--- a/src/net/PacketDispatch.h
+++ b/src/net/PacketDispatch.h
@@ -1,0 +1,50 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+#pragma once
+
+#include "net/PacketReader.h"
+
+#include <cstdint>
+
+// Shared observer for INCOMING packets — the receive-side mirror of
+// `Net::SendObserver`. The engine's SMSG dispatch funnel
+// (`FUN_NET_MESSAGE_DISPATCH`) is the single chokepoint every dispatched SMSG
+// passes through *before* the engine's per-opcode handler runs.
+//
+// Why this exists: co-existing DLLs (notably nampower via hadesmem, plus
+// SuperWoW) MinHook/detour the individual per-opcode SMSG handlers
+// (SpellGo/SpellStart/SpellDelayed/…). Two inline hookers on the same prologue
+// is the documented collision risk. nampower does NOT hook this funnel — it
+// hooks the leaf handlers — so any feature that only needs to *read* an
+// incoming packet subscribes here instead, and we stop sharing those
+// prologues. One hook on a function nobody else patches replaces N hooks on
+// functions everybody patches.
+//
+// Declare a file-scope
+//   static const Net::PacketDispatch::AutoSubscribe _sub{&callback};
+// Each callback receives the u16 `opcode` (already read) and the `CDataStore`
+// positioned **right after the opcode** (body start), exactly as the engine's
+// per-opcode handler would see it. The dispatcher resets that cursor before
+// every subscriber (so they read independently) and restores the original
+// `m_read` before handing the packet to the engine. Callbacks must only
+// READ — never mutate the packet — and must filter on `opcode` themselves.
+
+namespace Net::PacketDispatch {
+
+using Callback = void (*)(uint32_t opcode, CDataStore *packet);
+
+struct AutoSubscribe {
+    explicit AutoSubscribe(Callback cb);
+    Callback cb;
+    AutoSubscribe *next;
+};
+
+} // namespace Net::PacketDispatch

--- a/src/net/PacketObserver.h
+++ b/src/net/PacketObserver.h
@@ -1,0 +1,66 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+#pragma once
+
+#include "net/PacketReader.h"
+
+#include <cstdint>
+
+// Shared plumbing for the two packet-observer funnels — the outgoing
+// `Net::SendObserver` (CMSG, u32 opcode) and the incoming `Net::PacketDispatch`
+// (SMSG, u16 opcode). Both co-hook a single engine chokepoint and fan each
+// packet out to opcode subscribers; the only real differences are the opcode
+// width and the hooked function's ABI. Everything else — the intrusive
+// subscriber list, the subscribe helper, and the read-opcode / reset-cursor /
+// fan-out / restore-cursor loop — lives here so a fix to the fan-out logic
+// isn't made twice.
+//
+// Each observer keeps its own file-scope `PacketSubscriber *g_head` and defines
+// a thin `AutoSubscribe` in its own namespace (so call sites stay
+// `Net::PacketDispatch::AutoSubscribe{&cb}`); the shared pieces below do the
+// work.
+
+namespace Net {
+
+using PacketCallback = void (*)(uint32_t opcode, CDataStore *packet);
+
+// Intrusive node for an observer's subscriber list. Each observer's
+// `AutoSubscribe` derives from this and chains itself on at static-init time.
+struct PacketSubscriber {
+    PacketCallback cb;
+    PacketSubscriber *next;
+};
+
+// Chains `node` (already carrying its `cb`) onto `head`.
+inline void Subscribe(PacketSubscriber *&head, PacketSubscriber *node,
+                      PacketCallback cb) {
+    node->cb = cb;
+    node->next = head;
+    head = node;
+}
+
+// Reads the leading opcode (width `OpcodeT`) at the packet's current cursor,
+// then invokes every subscriber with the cursor reset to the body before each
+// (so they read independently) and the original `m_read` restored afterward —
+// so the engine (and any leaf-handler hooks) see an untouched packet.
+template <typename OpcodeT>
+inline void FanOutByOpcode(PacketSubscriber *head, CDataStore *packet) {
+    const uint32_t saved = packet->m_read;
+    const uint32_t opcode = static_cast<uint32_t>(Read<OpcodeT>(packet));
+    const uint32_t afterOpcode = packet->m_read;
+    for (auto *node = head; node != nullptr; node = node->next) {
+        packet->m_read = afterOpcode; // each subscriber reads independently
+        node->cb(opcode, packet);
+    }
+    packet->m_read = saved; // hand the engine an untouched cursor
+}
+
+} // namespace Net

--- a/src/net/PacketReader.h
+++ b/src/net/PacketReader.h
@@ -13,7 +13,8 @@
 #include <cstdint>
 
 // Minimal reader for the engine's `CDataStore` packet buffer, shared by the
-// packet co-hooks (`Aura::Source`'s SpellGo, `Spell::Cast`'s SpellStart).
+// packet-observer subscribers (`Aura::Source`'s SpellGo, `Spell::Cast`'s
+// SpellStart, …) that read incoming SMSGs via `Net::PacketDispatch`.
 //
 // `CDataStore` is POLYMORPHIC in the engine (virtual Internal*/Reset/etc.),
 // so a vtable pointer sits at offset 0 and the data members start at +0x04.

--- a/src/net/SendObserver.cpp
+++ b/src/net/SendObserver.cpp
@@ -20,7 +20,7 @@ namespace Net::SendObserver {
 
 namespace {
 
-AutoSubscribe *g_head = nullptr;
+PacketSubscriber *g_head = nullptr;
 
 // `FUN_NET_SEND` — `__thiscall(conn, CDataStore*)`, rendered here as
 // `__fastcall(conn /*ecx*/, edx, packet)`. The leading u32 of the buffer is
@@ -29,23 +29,15 @@ using NetSend_t = void(__fastcall *)(void *conn, void *edx, CDataStore *packet);
 NetSend_t g_origNetSend = nullptr;
 
 void __fastcall NetSend_h(void *conn, void *edx, CDataStore *packet) {
-    if (packet != nullptr && g_head != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint32_t opcode = Net::Read<uint32_t>(packet);
-        const uint32_t afterOpcode = packet->m_read;
-        for (auto *node = g_head; node != nullptr; node = node->next) {
-            packet->m_read = afterOpcode; // each subscriber reads independently
-            node->cb(opcode, packet);
-        }
-        packet->m_read = saved; // hand the engine an untouched cursor
-    }
+    if (packet != nullptr && g_head != nullptr)
+        Net::FanOutByOpcode<uint32_t>(g_head, packet); // opcode is a u32 CMSG id
     g_origNetSend(conn, edx, packet);
 }
 
 } // namespace
 
-AutoSubscribe::AutoSubscribe(Callback cb) : cb(cb), next(g_head) {
-    g_head = this;
+AutoSubscribe::AutoSubscribe(Net::PacketCallback cb) {
+    Net::Subscribe(g_head, this, cb);
 }
 
 static const Game::HookAutoRegister _hook{

--- a/src/net/SendObserver.h
+++ b/src/net/SendObserver.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "net/PacketObserver.h"
 #include "net/PacketReader.h"
 
 #include <cstdint>
@@ -33,12 +34,11 @@
 
 namespace Net::SendObserver {
 
-using Callback = void (*)(uint32_t opcode, CDataStore *packet);
-
-struct AutoSubscribe {
-    explicit AutoSubscribe(Callback cb);
-    Callback cb;
-    AutoSubscribe *next;
+// Chains onto the outgoing-packet subscriber list at static-init time. The
+// list plumbing + fan-out live in net/PacketObserver.h (shared with
+// Net::PacketDispatch).
+struct AutoSubscribe : Net::PacketSubscriber {
+    explicit AutoSubscribe(Net::PacketCallback cb);
 };
 
 } // namespace Net::SendObserver

--- a/src/spell/AtUnit.cpp
+++ b/src/spell/AtUnit.cpp
@@ -45,6 +45,7 @@
 
 #include "Game.h"
 #include "spell/AtCursor.h"
+#include "spell/AtUnit.h"
 #include "spell/MacroPrimarySpell.h"
 #include "unit/Identity.h"
 #include "unit/Position.h"
@@ -54,6 +55,33 @@
 namespace Spell::AtUnit {
 
 namespace {
+
+// The shared cast-at-unit core, used by both the Lua entry and the C++ API.
+// Resolves the token once → object, reads position + GUID, dispatches the cast
+// WITH that GUID, then handles the ground-spell placement branch. `byNumber`
+// selects spellID vs spellName. Fail-fast so a bad/absent unit doesn't leave
+// the engine mid-cast.
+bool CastCore(const char *token, bool byNumber, int spellID, const char *spellName) {
+    void *unitObj = Unit::Position::ResolveToken(token);
+    float pos[3];
+    if (unitObj == nullptr || !Unit::Position::Read(unitObj, pos))
+        return false;
+    const uint64_t targetGuid = Unit::Identity::GuidForObject(unitObj);
+
+    const bool dispatched =
+        byNumber ? Spell::AtCursor::DispatchSpellCast(spellID, targetGuid)
+                 : Spell::AtCursor::DispatchSpellCastByName(spellName, targetGuid);
+    if (!dispatched)
+        return false;
+
+    // Unit-target / normal spells fired straight at the GUID — no placement.
+    // Ground spells are now sitting in placement mode; commit at the unit's
+    // feet (CommitAtCoords cancels + fails for a non-ground placement, i.e.
+    // an unaccepted unit target).
+    if (!Spell::AtCursor::IsPlacementActive())
+        return true;
+    return Spell::AtCursor::CommitAtCoords(pos);
+}
 
 int __fastcall Script_C_Spell_CastAtUnit(void *L) {
     // arg1: numeric spellID (exact rank) or spell name ("(Rank N)"-aware).
@@ -65,38 +93,12 @@ int __fastcall Script_C_Spell_CastAtUnit(void *L) {
         return 1;
     }
     const char *token = Game::Lua::ToString(L, 2);
-
-    // Resolve the unit once → object, then read position + GUID from it.
-    // Fail fast so a bad/absent unit doesn't leave the engine mid-cast.
-    void *unitObj = Unit::Position::ResolveToken(token);
-    float pos[3];
-    if (unitObj == nullptr || !Unit::Position::Read(unitObj, pos)) {
-        Game::Lua::PushBool(L, false);
-        return 1;
-    }
-    const uint64_t targetGuid = Unit::Identity::GuidForObject(unitObj);
-
-    const bool dispatched =
+    const bool ok =
         byNumber
-            ? Spell::AtCursor::DispatchSpellCast(
-                  static_cast<int>(Game::Lua::ToNumber(L, 1)), targetGuid)
-            : Spell::AtCursor::DispatchSpellCastByName(Game::Lua::ToString(L, 1),
-                                                       targetGuid);
-    if (!dispatched) {
-        Game::Lua::PushBool(L, false);
-        return 1;
-    }
-
-    // Unit-target / normal spells fired straight at the GUID — no placement.
-    // Ground spells are now sitting in placement mode; commit at the unit's
-    // feet (CommitAtCoords cancels + fails for a non-ground placement, i.e.
-    // an unaccepted unit target).
-    if (!Spell::AtCursor::IsPlacementActive()) {
-        Game::Lua::PushBool(L, true);
-        return 1;
-    }
-    const bool placed = Spell::AtCursor::CommitAtCoords(pos);
-    Game::Lua::PushBool(L, placed);
+            ? CastCore(token, true, static_cast<int>(Game::Lua::ToNumber(L, 1)),
+                       nullptr)
+            : CastCore(token, false, 0, Game::Lua::ToString(L, 1));
+    Game::Lua::PushBool(L, ok);
     return 1;
 }
 
@@ -130,5 +132,19 @@ const Spell::MacroPrimarySpell::PatternAutoRegister _patreg{
     "C_Spell.CastAtUnit(", &ExtractCastAtUnitArg};
 
 } // namespace
+
+// ---- C++ API (see AtUnit.h) — same core as the Lua entry, no round-trip -----
+
+bool CastByName(const char *spellName, const char *unitToken) {
+    if (spellName == nullptr || unitToken == nullptr)
+        return false;
+    return CastCore(unitToken, false, 0, spellName);
+}
+
+bool CastByID(int spellID, const char *unitToken) {
+    if (unitToken == nullptr)
+        return false;
+    return CastCore(unitToken, true, spellID, nullptr);
+}
 
 } // namespace Spell::AtUnit

--- a/src/spell/AtUnit.h
+++ b/src/spell/AtUnit.h
@@ -1,0 +1,35 @@
+// This file is part of ClassicAPI.
+//
+// ClassicAPI is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+//
+// ClassicAPI is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// ClassicAPI. If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+// C++ entry to the cast-at-unit primitive behind `C_Spell.CastAtUnit`, so
+// other C++ modules (the Frame attribute click dispatcher's `spell` verb) can
+// cast a spell at a unit without a Lua round-trip through the global table.
+//
+// Both feed the unit's GUID straight to the engine's cast dispatcher — a
+// unit-target/normal spell fires directly on the unit (no current-target
+// juggling), a ground-target spell lands at the unit's feet. Returns true when
+// the spell was cast. Safe to call from inside a Lua C function: a genuinely
+// unknown token raises the engine's standard "Unknown unit" error in the
+// resolver, caught by the enclosing protected call.
+
+namespace Spell::AtUnit {
+
+// Cast by name ("(Rank N)"-aware — `"Blizzard"` is the highest known rank).
+bool CastByName(const char *spellName, const char *unitToken);
+
+// Cast the exact numeric spellID (a specific rank).
+bool CastByID(int spellID, const char *unitToken);
+
+} // namespace Spell::AtUnit

--- a/src/spell/Cast.cpp
+++ b/src/spell/Cast.cpp
@@ -71,6 +71,7 @@
 #include "Game.h"
 #include "Offsets.h"
 #include "dbc/Lookup.h"
+#include "net/PacketDispatch.h"
 #include "net/PacketReader.h"
 #include "spell/Lookup.h"
 #include "spell/CastEvents.h"
@@ -485,131 +486,73 @@ void HandleSpellStart(uint64_t caster, int spellID, uint32_t castTime) {
                                              instantChannel);
 }
 
-// Co-hook on the SMSG_SPELL_START handler. Gated on opCode 0x131 so every
-// other packet this handler processes is a cheap early-out. Packet layout
-// mirrors nampower's SpellStartHandlerHook.
-using SpellStartHandler_t = int(__fastcall *)(uint32_t unk, uint32_t opCode,
-                                              uint32_t unk2,
-                                              Net::CDataStore *packet);
-SpellStartHandler_t g_origSpellStart = nullptr;
-
-int __fastcall SpellStartHandler_h(uint32_t unk, uint32_t opCode,
-                                   uint32_t unk2, Net::CDataStore *packet) {
-    if (opCode == 0x131 && packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        Net::ReadPackedGuid(packet); // itemGuid (unused)
-        const uint64_t caster = Net::ReadPackedGuid(packet);
-        const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
-        Net::Read<uint16_t>(packet); // castFlags (unused)
-        const uint32_t castTime = Net::Read<uint32_t>(packet);
-        packet->m_read = saved; // restore before the engine re-parses
-        HandleSpellStart(caster, spellID, castTime);
-    }
-    return g_origSpellStart(unk, opCode, unk2, packet);
+// SMSG_SPELL_START parse. Body (mirrored from nampower's SpellStartHandler):
+// itemGuid(packed), casterGuid(packed), spellId(u32), castFlags(u16),
+// castTime(u32). Runs from the Net::PacketDispatch funnel with the cursor
+// already positioned at the body.
+void ParseSpellStart(Net::CDataStore *packet) {
+    Net::ReadPackedGuid(packet); // itemGuid (unused)
+    const uint64_t caster = Net::ReadPackedGuid(packet);
+    const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
+    Net::Read<uint16_t>(packet); // castFlags (unused)
+    const uint32_t castTime = Net::Read<uint32_t>(packet);
+    HandleSpellStart(caster, spellID, castTime);
 }
 
-const Game::HookAutoRegister _spellStartHook{
-    Offsets::FUN_SPELL_START_HANDLER,
-    reinterpret_cast<void *>(&SpellStartHandler_h),
-    reinterpret_cast<void **>(&g_origSpellStart)};
-
-// Co-hook on the SMSG_SPELL_DELAYED handler — cast pushback. The server
-// only sends it to the affected caster, so it's effectively always the
-// local player; extend the tracked cast's end time (and report the
-// accumulated delay as delayTimeMs) so an addon's bar stretches on damage.
-using SpellDelayed_t = int(__stdcall *)(uint32_t *opCode,
-                                        Net::CDataStore *packet);
-SpellDelayed_t g_origSpellDelayed = nullptr;
-
-int __stdcall SpellDelayed_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint64_t guid = Net::Read<uint64_t>(packet);
-        const uint32_t delay = Net::Read<uint32_t>(packet);
-        packet->m_read = saved;
-        if (delay != 0 && g_cast.spellID != 0 &&
-            guid == Unit::Identity::PlayerGuid()) {
-            g_cast.endMs += static_cast<int>(delay);
-            g_cast.delayMs += static_cast<int>(delay);
-        }
+// SMSG_SPELL_DELAYED — cast pushback. The server only sends it to the
+// affected caster, so it's effectively always the local player; extend the
+// tracked cast's end (and report the accumulated delay as delayTimeMs) so an
+// addon's bar stretches on damage. Body: guid(u64), delay(u32).
+void ParseSpellDelayed(Net::CDataStore *packet) {
+    const uint64_t guid = Net::Read<uint64_t>(packet);
+    const uint32_t delay = Net::Read<uint32_t>(packet);
+    if (delay != 0 && g_cast.spellID != 0 &&
+        guid == Unit::Identity::PlayerGuid()) {
+        g_cast.endMs += static_cast<int>(delay);
+        g_cast.delayMs += static_cast<int>(delay);
     }
-    return g_origSpellDelayed(opCode, packet);
 }
 
-const Game::HookAutoRegister _spellDelayedHook{
-    Offsets::FUN_SPELL_DELAYED, reinterpret_cast<void *>(&SpellDelayed_h),
-    reinterpret_cast<void **>(&g_origSpellDelayed)};
-
-// Co-hook on the MSG_CHANNEL_START handler — the server tells the caster a
-// channel has begun, with the server-authoritative (modifier-applied)
-// duration. Sent only to the caster, so it's always the local player. This
-// is what makes CAST-THEN-CHANNEL spells (Mind Control: 3 s cast, then a
-// 60 s channel) show both phases: their SMSG_SPELL_START carries the cast
-// (castTime > 0, handled as a regular cast in HandleSpellStart) and only
-// this packet marks the channel actually starting. For instant channels it
-// re-stamps what the SpellStart path just wrote (same moment, server
-// duration) — harmless. We stamp before the original runs so the data is
-// fresh when the engine fires SPELLCAST_CHANNEL_START. Packet layout
-// mirrored from nampower's SpellChannelStartHandlerHook:
+// MSG_CHANNEL_START — the server tells the caster a channel has begun, with
+// the server-authoritative (modifier-applied) duration. Sent only to the
+// caster, so always the local player. This is what makes CAST-THEN-CHANNEL
+// spells (Mind Control: 3 s cast, then a 60 s channel) show both phases:
+// their SMSG_SPELL_START carries the cast (castTime > 0, handled as a regular
+// cast in HandleSpellStart) and only this packet marks the channel starting.
+// For instant channels it re-stamps what the SpellStart path just wrote (same
+// moment, server duration) — harmless. Running from the dispatch funnel keeps
+// the stamp ahead of the engine's leaf handler (which fires
+// SPELLCAST_CHANNEL_START), so the data is fresh when addons poll. Body:
 // spellId(u32), durationMs(u32).
-using ChannelStart_t = int(__stdcall *)(uint32_t *opCode,
-                                        Net::CDataStore *packet);
-ChannelStart_t g_origChannelStart = nullptr;
-
-int __stdcall ChannelStart_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
-        const uint32_t duration = Net::Read<uint32_t>(packet);
-        packet->m_read = saved;
-        if (spellID != 0 && duration > 0) {
-            const int now = NowMs();
-            StampChannel(spellID, now, now + static_cast<int>(duration));
-        }
+void ParseChannelStart(Net::CDataStore *packet) {
+    const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
+    const uint32_t duration = Net::Read<uint32_t>(packet);
+    if (spellID != 0 && duration > 0) {
+        const int now = NowMs();
+        StampChannel(spellID, now, now + static_cast<int>(duration));
     }
-    return g_origChannelStart(opCode, packet);
 }
 
-const Game::HookAutoRegister _channelStartHook{
-    Offsets::FUN_SPELL_CHANNEL_START,
-    reinterpret_cast<void *>(&ChannelStart_h),
-    reinterpret_cast<void **>(&g_origChannelStart)};
-
-// MSG_CHANNEL_UPDATE (0x006e75f0) — sent to the channeling PLAYER on damage
-// pushback (vanilla channels SHORTEN when hit) and once more at the channel's
-// end (remaining == 0). Body is a single u32 = the new remaining time (ms);
-// the spell is the in-progress channel (the packet carries no spellID, same as
-// the engine's own handler). The engine fires its Lua SPELLCAST_CHANNEL_UPDATE
-// but stores the new end nowhere, so g_channel.endMs — computed once at start —
-// would keep reporting the full, un-pushed-back duration through
-// UnitChannelInfo. Re-anchor it to the server's remaining time so the query
-// (and the OnWorldTick endMs self-expiry) track pushback; on remaining == 0
-// clear the channel so CHANNEL_STOP fires promptly (ahead of the ~1 s-lagged
-// +0x228 field).
-using ChannelUpdate_t = int(__stdcall *)(uint32_t *opCode,
-                                         Net::CDataStore *packet);
-ChannelUpdate_t g_origChannelUpdate = nullptr;
-
-int __stdcall ChannelUpdate_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr && g_channel.spellID != 0) {
-        const uint32_t saved = packet->m_read;
-        const uint32_t remaining = Net::Read<uint32_t>(packet);
-        packet->m_read = saved;
-        const int spellID = g_channel.spellID;
-        if (remaining == 0) {
-            g_channel.spellID = 0; // authoritative channel end
-        } else {
-            g_channel.endMs = NowMs() + static_cast<int>(remaining);
-            Spell::CastEvents::OnPlayerChannelUpdate(spellID);
-        }
+// MSG_CHANNEL_UPDATE — sent to the channeling PLAYER on damage pushback
+// (vanilla channels SHORTEN when hit) and once more at the channel's end
+// (remaining == 0). Body is a single u32 = the new remaining time (ms); the
+// spell is the in-progress channel (the packet carries no spellID). The engine
+// stores the new end nowhere, so re-anchor g_channel.endMs to the server's
+// remaining time so UnitChannelInfo (and the OnWorldTick endMs self-expiry)
+// track pushback; on remaining == 0 clear the channel so CHANNEL_STOP fires
+// promptly (ahead of the ~1 s-lagged +0x228 field).
+void ParseChannelUpdate(Net::CDataStore *packet) {
+    if (g_channel.spellID == 0)
+        return;
+    const uint32_t remaining = Net::Read<uint32_t>(packet);
+    const int spellID = g_channel.spellID;
+    if (remaining == 0) {
+        g_channel.spellID = 0; // authoritative channel end
+    } else {
+        g_channel.endMs = NowMs() + static_cast<int>(remaining);
+        Spell::CastEvents::OnPlayerChannelUpdate(spellID);
     }
-    return g_origChannelUpdate(opCode, packet);
 }
-
-const Game::HookAutoRegister _channelUpdateHook{
-    Offsets::FUN_SPELL_CHANNEL_UPDATE,
-    reinterpret_cast<void *>(&ChannelUpdate_h),
-    reinterpret_cast<void **>(&g_origChannelUpdate)};
 
 // Shared abort handling for the two sibling failure packets. Servers
 // derived from (v)mangos broadcast BOTH `SMSG_SPELL_FAILURE` and
@@ -644,56 +587,18 @@ void HandleCastAborted(uint64_t guid, int spellID) {
     Spell::CastEvents::OnRemoteAborted(guid, spellID);
 }
 
-// Co-hook on the SMSG_SPELL_FAILED_OTHER handler — the server broadcasts it
-// to observers whenever a started cast aborts (interrupt, death, movement,
-// fizzle). It's what lets us drop a remote cast the moment it dies instead
-// of letting the ghost bar run to its computed end (the documented
-// remote-unit limitation above). Packet body is plain (not packed):
-// casterGuid(u64), spellId(u32).
-using SpellFailedOther_t = int(__stdcall *)(uint32_t *opCode,
-                                            Net::CDataStore *packet);
-SpellFailedOther_t g_origSpellFailedOther = nullptr;
-
-int __stdcall SpellFailedOther_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint64_t guid = Net::Read<uint64_t>(packet);
-        const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
-        packet->m_read = saved;
-        HandleCastAborted(guid, spellID);
-    }
-    return g_origSpellFailedOther(opCode, packet);
+// SMSG_SPELL_FAILURE / SMSG_SPELL_FAILED_OTHER — sibling abort packets. The
+// server broadcasts one (which varies by core / abort path) to observers when
+// a started cast aborts (interrupt, death, movement, fizzle); handling both
+// makes eviction independent of which the server chose. Both share the head
+// casterGuid(u64), spellId(u32) — plain, not packed (SpellFailure has a
+// trailing result(u8) we don't read). Drops a remote cast the moment it dies
+// instead of letting the ghost bar run to its computed end.
+void ParseCastAborted(Net::CDataStore *packet) {
+    const uint64_t guid = Net::Read<uint64_t>(packet);
+    const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
+    HandleCastAborted(guid, spellID);
 }
-
-const Game::HookAutoRegister _spellFailedOtherHook{
-    Offsets::FUN_SPELL_FAILED_OTHER,
-    reinterpret_cast<void *>(&SpellFailedOther_h),
-    reinterpret_cast<void **>(&g_origSpellFailedOther)};
-
-// Co-hook on the SMSG_SPELL_FAILURE handler — FAILED_OTHER's sibling, with
-// a trailing result(u8) after the same casterGuid(u64), spellId(u32) head
-// (we don't read the result). This is the packet that actually stops the
-// caster's cast VISUAL in the engine's own handler, so it demonstrably
-// arrives for interrupts; hooking both siblings makes the eviction
-// independent of which one the server chose to send.
-using SpellFailure_t = int(__stdcall *)(uint32_t *opCode,
-                                        Net::CDataStore *packet);
-SpellFailure_t g_origSpellFailure = nullptr;
-
-int __stdcall SpellFailure_h(uint32_t *opCode, Net::CDataStore *packet) {
-    if (packet != nullptr) {
-        const uint32_t saved = packet->m_read;
-        const uint64_t guid = Net::Read<uint64_t>(packet);
-        const int spellID = static_cast<int>(Net::Read<uint32_t>(packet));
-        packet->m_read = saved;
-        HandleCastAborted(guid, spellID);
-    }
-    return g_origSpellFailure(opCode, packet);
-}
-
-const Game::HookAutoRegister _spellFailureHook{
-    Offsets::FUN_SPELL_FAILURE, reinterpret_cast<void *>(&SpellFailure_h),
-    reinterpret_cast<void **>(&g_origSpellFailure)};
 
 // Co-hook on CGUnit_C::ClearCastingSpell — the engine choke point every
 // "unit stopped casting" path funnels through (failure packets, SPELL_GO,
@@ -728,6 +633,29 @@ const Game::HookAutoRegister _clearCastingHook{
     Offsets::FUN_UNIT_CLEAR_CASTING_SPELL,
     reinterpret_cast<void *>(&ClearCastingSpell_h),
     reinterpret_cast<void **>(&g_origClearCastingSpell)};
+
+// One subscriber on the SMSG dispatch funnel, replacing the six per-opcode
+// co-hooks these spell packets used to install (SpellStart / Delayed /
+// ChannelStart / ChannelUpdate / Failure / FailedOther) — every one of which
+// nampower also detours. The dispatcher hands us the cursor at the body (the
+// opcode already consumed). CastStartSet and ClearCastingSpell stay direct
+// hooks: they're engine methods, not SMSG handlers, so the funnel can't reach
+// them (and ClearCastingSpell is the SuperWoW-shared interrupt choke point).
+void SpellPacketSub(uint32_t opcode, Net::CDataStore *packet) {
+    if (packet == nullptr)
+        return;
+    switch (opcode) {
+    case Offsets::SMSG_SPELL_START:          ParseSpellStart(packet); break;
+    case Offsets::SMSG_SPELL_DELAYED:        ParseSpellDelayed(packet); break;
+    case Offsets::SMSG_SPELL_CHANNEL_START:  ParseChannelStart(packet); break;
+    case Offsets::SMSG_SPELL_CHANNEL_UPDATE: ParseChannelUpdate(packet); break;
+    case Offsets::SMSG_SPELL_FAILURE:
+    case Offsets::SMSG_SPELL_FAILED_OTHER:   ParseCastAborted(packet); break;
+    default:                                 break;
+    }
+}
+
+const Net::PacketDispatch::AutoSubscribe _spellPacketSub{&SpellPacketSub};
 
 } // namespace
 


### PR DESCRIPTION
## Summary
Three related pieces of engine work on this branch:

### 1. Frame attribute API backport
- `Frame:SetAttribute` / `GetAttribute` / `ClearAttribute` (retail 11.2.0),
  stored in the Lua registry (hidden from Lua), with the one-verb click
  dispatcher and `OnAttributeChanged`.
- `item` and `target` click verbs (SecureActionButton semantics); `target`
  clears on unit `"none"`. Unit-frame mouseover/click support.

### 2. Modern positional script arguments (opt-in)
- `frame:SetScript("OnMouseWheel", function(self, delta) ... end)` — handlers get
  `(self, [event,] arg1..argN)` like later clients, on top of the vanilla
  `this`/`arg1`/`event` globals (purely additive).
- Reimplements both frame-script runners' pcall tail to push positional args;
  OnEvent gets `event` as the 2nd positional (detected structurally).
- **Opt-in** via `SetModernScriptArgs(true)` — off by default, since it lands on
  the engine's hottest Lua path.

### 3. SMSG hook consolidation — `Net::PacketDispatch`
- One co-hook on the incoming-SMSG dispatch funnel (`FUN_NET_MESSAGE_DISPATCH`)
  fanning packets to opcode subscribers.
- Migrates 8 spell-subsystem SMSG handlers (SpellGo/Start/Delayed/Channel*/
  Failure*/Cooldown) off their per-opcode co-hooks — a funnel nampower/SuperWoW
  don't hook. Cuts the ClassicAPI-nampower shared spell prologues from 10 to 3,
  removing the packet-path MinHook collision surface.

## Testing
Validated in-game: attribute click-casting + `OnAttributeChanged`; every
script-runner path with modern args enabled; and the full spell-cast surface
(cast bars, channels incl. Mind Control, pushback, remote-cast interrupt
eviction, `C_LossOfControl`) after the consolidation.
