### PR TITLE
feat(aura): recognise the Carnage refresh from the combo point it returns

### DIFF
--- a/AddOns/!!!ClassicAPI/Util/AuraDurationModifiers.lua
+++ b/AddOns/!!!ClassicAPI/Util/AuraDurationModifiers.lua
@@ -18,12 +18,13 @@
 -- RegisterAuraDurationModifierByTrigger matches it by SpellFamilyName + school
 -- index instead (see Shadow Weaving below).
 --
--- NOT included on purpose: Carnage's Rip/Rake refresh fires behind a
--- server-side probability roll on Ferocious Bite. The client can't know the
--- roll's outcome, so inferring it would show wrong timers. If you accept that,
--- register it yourself, e.g. (DRUID = 7):
---   C_UnitAuras.RegisterAuraDurationModifier(<ferociousBiteID>, 7, tonumber("800000",16), 108, "refresh") -- Rip
---   C_UnitAuras.RegisterAuraDurationModifier(<ferociousBiteID>, 7, tonumber("1000",16),   494, "refresh") -- Rake
+-- Carnage (druid) is the case a rule cannot express, and is handled at the
+-- bottom of this file instead: its refresh fires behind a per-combo-point
+-- probability roll, so keying it on the Ferocious Bite cast alone would
+-- over-refresh at every rank but 2/2 spending five points. The roll's outcome
+-- IS observable -- it returns a combo point -- but that arrives as a combo
+-- point change rather than a packet, which is not something the trigger
+-- matching here can see.
 -- Conflagrate's *full*-consume variant (other servers) removes Immolate
 -- outright; that clears the aura slot and ClassicAPI evicts it via the normal
 -- removal path, so the reduce rule below is harmless there and correct on
@@ -67,4 +68,61 @@ EventUtil.RegisterOnceFrameEventAndCallback("SPELLS_CHANGED", function()
     if IsPlayerSpell(15334) then
         C_UnitAuras.RegisterAuraDurationModifierByTrigger(PRIEST, SHADOW, PRIEST, SW_FLAG, SW_ICON, "refresh")
     end
+end)
+
+-- Carnage (druid): Ferocious Bite gains a chance PER COMBO POINT SPENT (10% at
+-- rank 1, 20% at rank 2) to refresh the caster's Rake and Rip and to grant an
+-- additional combo point. The refresh emits no packet and the proc applies no
+-- aura, so no trigger rule can see it -- but the granted point can be:
+-- Ferocious Bite spends every point, so a gain right after one is the proc.
+-- Only 2/2 spending five is certain, so confirming beats assuming; refreshing
+-- on every Bite would show a full timer on a DoT about to fall off.
+--
+-- Rip and Rake are matched by family flags (every rank, server additions
+-- included); Ferocious Bite is an ID list like the triggers above. An unlisted
+-- rank under-triggers, leaving the timer as it is today.
+local DRUID = 7
+local RIP_FLAG,  RIP_ICON  = tonumber("800000", 16), 108
+local RAKE_FLAG, RAKE_ICON = tonumber("1000", 16),   494
+local FEROCIOUS_BITE = {
+    [22568] = 1, [22827] = 1, [22828] = 1, [22829] = 1, [31018] = 1,
+}
+
+-- Long enough to absorb latency, short enough that the GCD the Bite just
+-- started excludes any other source of a combo point.
+local CARNAGE_WINDOW = 0.5
+
+local carnageGuid, carnageUntil
+
+-- At file load UnitClass has no player to answer for and returns nil, so the
+-- class gate would silently never register.
+EventUtil.ContinueOnPlayerLogin(function()
+    local _, class = UnitClass("player")
+    if class ~= "DRUID" then return end
+
+    local f = CreateFrame("Frame")
+    f:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+    f:RegisterEvent("PLAYER_COMBO_POINTS")
+    f:SetScript("OnEvent", function()
+        if event == "UNIT_SPELLCAST_SUCCEEDED" then
+            if arg1 ~= "player" or not FEROCIOUS_BITE[arg3] then return end
+            -- Captured now, used later: the refresh belongs to the unit the
+            -- Bite hit, which need not still be the target.
+            carnageGuid, carnageUntil = UnitGUID("target"), GetTime() + CARNAGE_WINDOW
+            return
+        end
+
+        if not carnageGuid then return end
+        if GetTime() > carnageUntil then carnageGuid = nil; return end
+
+        -- The Bite spent every point, so the first change reported after it
+        -- already reflects that: 0 is a failed roll, anything above it is the
+        -- refund. Waiting to see the 0 would miss the proc whenever the server
+        -- coalesces spend and refund into one update (5 -> 1).
+        if GetComboPoints() > 0 then
+            C_UnitAuras.RefreshAuraDurationByFamily(carnageGuid, DRUID, RIP_FLAG, RIP_ICON)
+            C_UnitAuras.RefreshAuraDurationByFamily(carnageGuid, DRUID, RAKE_FLAG, RAKE_ICON)
+            carnageGuid = nil
+        end
+    end)
 end)

--- a/src/aura/Source.cpp
+++ b/src/aura/Source.cpp
@@ -19,6 +19,7 @@
 #include "Data.h"
 #include "Game.h"
 #include "Offsets.h"
+#include "guid/Guid.h"
 #include "net/PacketDispatch.h"
 #include "net/PacketReader.h"
 #include "player/StatSignal.h"
@@ -322,6 +323,31 @@ void Evict(uint64_t targetGuid, uint32_t spellId) {
     }
 }
 
+// `C_UnitAuras.RefreshAuraDurationByFamily(unit, family, familyFlags[, icon])`
+// -> spellID refreshed, or nil. The caster is always the local player. `unit`
+// takes a raw GUID string as well as a token: the caller observed something
+// about a specific unit, which a re-resolved token may no longer name.
+int __fastcall Script_RefreshAuraDurationByFamily(void *L) {
+    if (!Game::Lua::IsString(L, 1) || !Game::Lua::IsNumber(L, 2) ||
+        !Game::Lua::IsNumber(L, 3))
+        return 0;
+    const char *unit = Game::Lua::ToString(L, 1);
+    uint64_t guid = 0;
+    if (!Guid::Parse(unit, &guid))
+        guid = Unit::Identity::GuidForToken(unit);
+    const auto family = static_cast<uint32_t>(Game::Lua::ToNumber(L, 2));
+    const auto mask = static_cast<uint64_t>(Game::Lua::ToNumber(L, 3));
+    uint32_t icon = 0;
+    if (Game::Lua::IsNumber(L, 4))
+        icon = static_cast<uint32_t>(Game::Lua::ToNumber(L, 4));
+    const uint32_t spellId = RefreshDurationByFamily(
+        guid, family, mask, icon, Unit::Identity::PlayerGuid());
+    if (spellId == 0)
+        return 0;
+    Game::Lua::PushNumber(L, static_cast<double>(spellId));
+    return 1;
+}
+
 // ---- Server-side duration modifiers (trigger-driven inference) -----------
 //
 // Some server mechanics change a DoT's remaining time on another unit with
@@ -360,21 +386,29 @@ constexpr int kMaxMods = 128;
 DurationMod g_mods[kMaxMods];
 int g_modCount = 0;
 
-bool AffectedMatches(const uint8_t *rec, const DurationMod &m) {
+// The affected-aura selector alone, shared with the Lua-facing by-family
+// refresh so the two cannot disagree about what they match.
+bool AffectedMatchesRaw(const uint8_t *rec, uint32_t family, uint64_t mask,
+                        uint32_t icon) {
     if (rec == nullptr)
         return false;
     if (*reinterpret_cast<const uint32_t *>(
-            rec + Offsets::OFF_SPELL_RECORD_FAMILY_NAME) != m.affectedFamily)
+            rec + Offsets::OFF_SPELL_RECORD_FAMILY_NAME) != family)
         return false;
     const uint64_t flags = *reinterpret_cast<const uint64_t *>(
         rec + Offsets::OFF_SPELL_RECORD_FAMILY_FLAGS);
-    if ((flags & m.affectedMask) == 0)
+    if ((flags & mask) == 0)
         return false;
-    if (m.affectedIcon != 0 &&
+    if (icon != 0 &&
         *reinterpret_cast<const uint32_t *>(
-            rec + Offsets::OFF_SPELL_RECORD_ICON_ID) != m.affectedIcon)
+            rec + Offsets::OFF_SPELL_RECORD_ICON_ID) != icon)
         return false;
     return true;
+}
+
+bool AffectedMatches(const uint8_t *rec, const DurationMod &m) {
+    return AffectedMatchesRaw(rec, m.affectedFamily, m.affectedMask,
+                              m.affectedIcon);
 }
 
 // A rule's trigger matches either by exact spellID, or (triggerSpellId == 0)
@@ -575,6 +609,9 @@ void RegisterDurationModLua() {
     Game::Lua::RegisterTableFunction("C_UnitAuras",
                                      "RegisterAuraDurationModifierByTrigger",
                                      &Script_RegisterAuraDurationModifierByTrigger);
+    Game::Lua::RegisterTableFunction("C_UnitAuras",
+                                     "RefreshAuraDurationByFamily",
+                                     &Script_RefreshAuraDurationByFamily);
 }
 
 const Game::ModuleAutoRegister _autoregDurationMod{&RegisterDurationModLua};
@@ -865,6 +902,38 @@ bool Get(uint64_t unitGuid, uint32_t spellId, uint64_t *outCaster,
         }
     }
     return false;
+}
+
+uint32_t RefreshDurationByFamily(uint64_t unitGuid, uint32_t family,
+                                 uint64_t mask, uint32_t icon,
+                                 uint64_t casterGuid) {
+    if (unitGuid == 0 || mask == 0 || casterGuid == 0)
+        return 0;
+    const uint32_t now = NowMs();
+    for (auto &e : g_cache) {
+        if (!e.used || e.targetGuid != unitGuid)
+            continue;
+        // Caller's own aura only, scoped as ApplyDurationModifiers scopes a
+        // rule; a caster-less entry is claimed rather than skipped, same as
+        // there.
+        if (e.casterGuid != 0 && e.casterGuid != casterGuid)
+            continue;
+        if (!AffectedMatchesRaw(
+                Spell::Lookup::RecordForID(static_cast<int>(e.spellId)), family,
+                mask, icon))
+            continue;
+        if (e.durationMs == 0)
+            continue; // never invent a duration
+        if (e.casterGuid == 0)
+            e.casterGuid = casterGuid;
+        // The applied duration, not a recomputed one (the server's
+        // RefreshHolder): a Rip cast at 3 combo points returns to its own
+        // duration, not a five-point one.
+        e.expirationMs = now + e.durationMs;
+        e.stampMs = now;
+        return e.spellId;
+    }
+    return 0;
 }
 
 void EvictAbsent(uint64_t unitGuid, const uint32_t *presentSpellIds, int count) {

--- a/src/aura/Source.h
+++ b/src/aura/Source.h
@@ -42,6 +42,15 @@ namespace Aura::Source {
 bool Get(uint64_t unitGuid, uint32_t spellId, uint64_t *outCaster,
          uint32_t *outExpirationMs, uint32_t *outDurationMs);
 
+// Refreshes `casterGuid`'s aura on `unitGuid` matching the same selector the
+// duration rules use — SpellFamilyName + family-flag overlap + optional icon
+// (0 = any) — to a full duration from now. Returns the spellID refreshed, or 0
+// if nothing matched. For a mechanic whose duration edit reaches the client
+// too late to be attributed to a cast packet, so no rule can express it.
+uint32_t RefreshDurationByFamily(uint64_t unitGuid, uint32_t family,
+                                 uint64_t mask, uint32_t icon,
+                                 uint64_t casterGuid);
+
 // One cached aura, as returned by `Enumerate`.
 struct CachedAura {
     uint32_t spellId;


### PR DESCRIPTION
Carnage was excluded here on the grounds that the client cannot know the roll's outcome. It can: the proc grants an additional combo point, and Ferocious Bite spends every point it had, so a gain right after one is the roll landing. That arrives as a combo point change rather than a packet, so no trigger rule can express it — hence a watch armed on the Bite and confirmed on the change.

RefreshDurationByFamily applies the refresh, selecting the affected aura the way the rules already do (family + flags + icon) so every rank of Rip and Rake matches without an ID list, and scoped to the caller's own aura as ApplyDurationModifiers scopes a rule. It restores the applied duration rather than a recomputed one, which is what keeps a combo-scaled Rip correct.