### PR TITLE
fix(cooldown): read engine millisecond ticks as unsigned

### DIFF
--- a/src/item/Cooldown.cpp
+++ b/src/item/Cooldown.cpp
@@ -42,16 +42,22 @@ namespace {
 // `uint *` (the ItemStats cache lookup uses the integer both as a
 // hash key and as the field-zero match target, which is how it
 // inherits the pointer typing in the decomp).
+//
+// `outDuration` / `outStart` are *unsigned* millisecond ticks. Reading
+// the start into a signed `int` makes every timestamp negative once the
+// machine has been up past 2^31 ms (~24.9 days), which puts
+// `startTime + duration` in the past and makes every item read as off
+// cooldown. `Aura::Data` already stores these as `uint32_t`.
 using QueryItemCooldown_t = bool(__fastcall *)(uint32_t itemID,
-                                                int *outDuration,
-                                                int *outStart,
+                                                uint32_t *outDuration,
+                                                uint32_t *outStart,
                                                 uint32_t *outEnable);
 
 } // namespace
 
 void PushCooldown(void *L, int itemID) {
-    int durationMs = 0;
-    int startMs = 0;
+    uint32_t durationMs = 0;
+    uint32_t startMs = 0;
     uint32_t enable = 0;
     if (itemID > 0) {
         auto fn = reinterpret_cast<QueryItemCooldown_t>(

--- a/src/lossofcontrol/Info.cpp
+++ b/src/lossofcontrol/Info.cpp
@@ -57,9 +57,16 @@ namespace LossOfControl {
 namespace {
 
 using TickMs_t = uint32_t(__fastcall *)();
-int NowMs() {
-    return static_cast<int>(
-        reinterpret_cast<TickMs_t>(Offsets::FUN_OS_TICKCOUNT_MS)());
+uint32_t NowMs() {
+    return reinterpret_cast<TickMs_t>(Offsets::FUN_OS_TICKCOUNT_MS)();
+}
+
+// True once `deadlineMs` has been reached. Both operands wrap together,
+// so the signed difference stays correct across the 2^32 ms rollover —
+// the same idiom `Aura::Data::ExpirationElapsed` uses. A plain
+// `now < deadline` compare would invert for the ~24.9 days after a wrap.
+bool Reached(uint32_t nowMs, uint32_t deadlineMs) {
+    return static_cast<int32_t>(nowMs - deadlineMs) >= 0;
 }
 
 const char *SpellName(const uint8_t *rec) {
@@ -90,12 +97,15 @@ int SpellSchoolIndex(const uint8_t *rec) {
 
 // ---- School-interrupt lockout state (fed by SMSG_SPELL_COOLDOWN) -----------
 
-// One active lockout per school index (0..6); active while now < endMs.
+// One active lockout per school index (0..6); active until `Reached(endMs)`.
 // Self-expiring, per-process — a stale entry from before a relog is already
 // in the past on the shared uptime clock, so no reset is needed.
+// Unsigned, like every other tick store here: the OS counter wraps at
+// 2^32 ms and reading it into a signed `int` turns every timestamp
+// negative past 2^31 ms (~24.9 days uptime).
 struct SchoolLock {
-    int startMs;
-    int endMs;
+    uint32_t startMs;
+    uint32_t endMs;
 };
 SchoolLock g_schoolLock[Offsets::SPELL_SCHOOL_COUNT] = {};
 
@@ -137,9 +147,9 @@ void CooldownSub(uint32_t opcode, Net::CDataStore *packet) {
     // (ProhibitSpellSchool); single/varied packets are normal cooldowns and
     // ignored.
     if (count >= 2 && uniform && firstDur > 0 && schoolIdx >= 0) {
-        const int now = NowMs();
+        const uint32_t now = NowMs();
         g_schoolLock[schoolIdx].startMs = now;
-        g_schoolLock[schoolIdx].endMs = now + firstDur;
+        g_schoolLock[schoolIdx].endMs = now + static_cast<uint32_t>(firstDur);
     }
 }
 
@@ -152,17 +162,17 @@ struct LocEntry {
     int spellID;        // 0 = unknown (school interrupt)
     const uint8_t *rec; // spell record for name/icon; null for school interrupt
     int schoolMask;     // lockoutSchool
-    int startMs;        // 0 = unknown
-    int endMs;          // 0 = unknown / no timing
+    uint32_t startMs;   // 0 = unknown
+    uint32_t endMs;     // 0 = unknown / no timing
 };
 
 int BuildList(LocEntry *out, int maxOut) {
-    const int now = NowMs();
+    const uint32_t now = NowMs();
     int n = 0;
 
     // School-interrupt lockouts first.
     for (int s = 0; s < Offsets::SPELL_SCHOOL_COUNT && n < maxOut; ++s) {
-        if (g_schoolLock[s].endMs != 0 && now < g_schoolLock[s].endMs) {
+        if (g_schoolLock[s].endMs != 0 && !Reached(now, g_schoolLock[s].endMs)) {
             LocEntry &e = out[n++];
             e.locType = "SCHOOL_INTERRUPT";
             e.spellID = 0;
@@ -204,9 +214,9 @@ int BuildList(LocEntry *out, int maxOut) {
             uint32_t expMs = 0, durMs = 0;
             if (Aura::Source::Get(playerGuid, spellID, &caster, &expMs, &durMs) &&
                 expMs != 0) {
-                e.endMs = static_cast<int>(expMs);
+                e.endMs = expMs;
                 if (durMs != 0)
-                    e.startMs = static_cast<int>(expMs - durMs);
+                    e.startMs = expMs - durMs;
             }
         }
     }
@@ -302,7 +312,7 @@ int __fastcall Script_GetActiveLossOfControlData(void *L) {
         return 0; // nil
 
     const LocEntry &e = entries[index - 1];
-    const int now = NowMs();
+    const uint32_t now = NowMs();
 
     Game::Lua::NewTable(L);
     Game::Lua::SetFieldString(L, "locType", e.locType);
@@ -314,12 +324,14 @@ int __fastcall Script_GetActiveLossOfControlData(void *L) {
 
     // Timing (seconds, GetTime() epoch). Nullable — leave a field unset (nil)
     // when we don't know it, per the modern contract.
-    if (e.endMs != 0 && now < e.endMs) {
-        Game::Lua::SetFieldNumber(L, "timeRemaining", (e.endMs - now) * 0.001);
+    if (e.endMs != 0 && !Reached(now, e.endMs)) {
+        Game::Lua::SetFieldNumber(L, "timeRemaining",
+                                  static_cast<double>(e.endMs - now) * 0.001);
         if (e.startMs != 0) {
-            Game::Lua::SetFieldNumber(L, "startTime", e.startMs * 0.001);
-            Game::Lua::SetFieldNumber(L, "duration",
-                                      (e.endMs - e.startMs) * 0.001);
+            Game::Lua::SetFieldNumber(L, "startTime",
+                                      static_cast<double>(e.startMs) * 0.001);
+            Game::Lua::SetFieldNumber(
+                L, "duration", static_cast<double>(e.endMs - e.startMs) * 0.001);
         }
     }
 

--- a/src/spell/Cooldown.cpp
+++ b/src/spell/Cooldown.cpp
@@ -31,10 +31,17 @@ namespace Spell::Cooldown {
 
 namespace {
 
+// The engine writes an *unsigned* millisecond tick into `outStart`.
+// Reading it into a signed `int` makes every timestamp negative once
+// the machine has been up past 2^31 ms (~24.9 days): a real start of
+// 2697363158 ms comes back as -1597604138, and `startTime + duration`
+// then lands a month in the past, so callers see every cooldown as
+// already elapsed. `Aura::Data` already stores these as `uint32_t`
+// for the same reason.
 using QueryCooldown_t = void(__fastcall *)(int spellID, int bookType,
-                                            int *outDuration,
-                                            int *outStart,
-                                            int *outEnable);
+                                            uint32_t *outDuration,
+                                            uint32_t *outStart,
+                                            uint32_t *outEnable);
 
 int __fastcall Script_C_Spell_GetSpellCooldown(void *L) {
     const int spellID = Spell::Arg::ResolveSpellID(L, 1);
@@ -43,7 +50,7 @@ int __fastcall Script_C_Spell_GetSpellCooldown(void *L) {
 
     auto fn = reinterpret_cast<QueryCooldown_t>(
         static_cast<uintptr_t>(Offsets::FUN_SPELL_QUERY_COOLDOWN));
-    int durationMs = 0, startMs = 0, enable = 0;
+    uint32_t durationMs = 0, startMs = 0, enable = 0;
     fn(spellID, 0 /* bookType=player */, &durationMs, &startMs, &enable);
 
     Game::Lua::NewTable(L);


### PR DESCRIPTION
`C_Spell.GetSpellCooldown`, `GetItemCooldown` /
`C_Container.GetItemCooldown` and `C_LossOfControl` read the engine's unsigned millisecond tick into a signed `int`. Once the machine has been up past 2^31 ms (~24.9 days) every timestamp they return is one 2^32 ms period short, and negative.

Observed on a client with 31 days of uptime, for a spell with 9.1s left of a 10s cooldown:

    GetSpellCooldown(slot, BOOKTYPE_SPELL)  ->  start  2697363.158
    C_Spell.GetSpellCooldown(spellID)       ->  start -1597604.138

The two differ by exactly 4294967.296 (2^32 ms). `startTime + duration` then lands a month in the past, so every caller sees every spell and item as already off cooldown -- an addon gating on a cooldown silently stops gating. The vanilla slot-addressed getters are unaffected; this is only the backported by-ID shapes.

Stores these as `uint32_t`, matching `Aura::Data`, which already reads the same counter unsigned. `C_LossOfControl` additionally compared `now < endMs` directly; that inverts across the rollover, so it now goes through a `Reached()` helper using the wrap-safe signed-difference idiom `Aura::Data::ExpirationElapsed` already uses.

`Spell::Cast` stores ticks in `int` too, but converts through `static_cast<uint32_t>` in `PushMs` at the Lua boundary, so its output is already correct and it is left alone.