### PR TITLE
fix(texture): correct vertex-offset units and the corner-store contract

### DIFF
--- a/src/texture/Transform.cpp
+++ b/src/texture/Transform.cpp
@@ -291,11 +291,38 @@ int __fastcall Script_GetVertexOffset(void *L) {
     return 2;
 }
 
+// Debug binding: dump the drawn-quad corner array (+0xD4) and the resolved
+// layout rect, raw internal units, no conversion. Returns 12 numbers:
+// BLx,BLy, TLx,TLy, BRx,BRy, TRx,TRy, rectTop, rectLeft, rectBottom, rectRight.
+// Diagnostic-only — for corner-transform triage from Lua.
+int __fastcall Script_GetCorners(void *L) {
+    void *tex = nullptr;
+    if (Game::Lua::Type(L, 1) == Game::Lua::TYPE_TABLE)
+        tex = Game::Lua::ResolveObject(L, 1);
+    if (tex == nullptr) {
+        Game::Lua::Error(L, "Usage: texture:GetCorners()");
+        return 0;
+    }
+    const float *base = reinterpret_cast<const float *>(
+        reinterpret_cast<char *>(tex) + Offsets::OFF_SIMPLETEXTURE_CORNERS);
+    for (int i = 0; i < 4; ++i) {
+        Game::Lua::PushNumber(L, base[i * 3 + 0]);
+        Game::Lua::PushNumber(L, base[i * 3 + 1]);
+    }
+    float rect[4] = {0, 0, 0, 0};
+    void *anchor = reinterpret_cast<char *>(tex) + Offsets::OFF_REGION_ANCHOR;
+    reinterpret_cast<GetRect_t>(Offsets::FUN_REGION_GET_RECT)(anchor, nullptr, rect);
+    for (int i = 0; i < 4; ++i)
+        Game::Lua::PushNumber(L, rect[i]);
+    return 12;
+}
+
 const Game::Lua::FrameMethodEntry g_methods[] = {
     {"SetRotation", &Script_SetRotation},
     {"GetRotation", &Script_GetRotation},
     {"SetVertexOffset", &Script_SetVertexOffset},
     {"GetVertexOffset", &Script_GetVertexOffset},
+    {"GetCorners", &Script_GetCorners},
 };
 
 void RegisterLuaFunctions() {

--- a/src/texture/Transform.cpp
+++ b/src/texture/Transform.cpp
@@ -25,11 +25,12 @@
 // transform is written once and costs nothing per frame; a moving/resizing
 // region re-transforms automatically.
 //
-// Units: rotation is scale-invariant, but a vertex offset has a magnitude, so
-// the Lua offset (UI coordinate units, like SetPoint's x/y) is converted to the
-// engine's internal layout space with the same factor Tooltip::LinePool uses for
-// engine SetPoint (px * MUL / (DIV * 1024)). +offsetY is up (WoW UI space is
-// Y-up — the same convention that makes a positive rotation angle turn CCW).
+// Units: rotation is scale-invariant, but a vertex offset has a magnitude. The
+// Lua offset is in the texture's LOCAL pixels (like SetPoint's x/y), stored
+// raw, and converted to the engine's internal layout space inside WriteCorners
+// — see the y-down and effective-scale notes there. The retail contract holds
+// at the API surface: +offsetY moves a corner up on screen, a positive angle
+// turns counter-clockwise on screen.
 //
 // Corner order at +0xD4 is BL, TL, BR, TR. Retail's vertex indices map onto
 // those slots via VertexSlot(); the UPPER_LEFT_VERTEX / … globals are published
@@ -55,8 +56,8 @@ namespace {
 struct Xf {
     float angle = 0.0f;              // radians, 0 = no rotation
     float cxN = 0.5f, cyN = 0.5f;    // rotation pivot, normalized in the rect
-    float offX[4] = {0, 0, 0, 0};    // per-corner offset, internal units, BL/TL/BR/TR
-    float offY[4] = {0, 0, 0, 0};
+    float offX[4] = {0, 0, 0, 0};    // per-corner offset, CALLER's local px
+    float offY[4] = {0, 0, 0, 0};    // (+y up), BL/TL/BR/TR; converted at write
 
     bool active() const {
         if (angle != 0.0f)
@@ -79,22 +80,16 @@ using GetRect_t = int(__fastcall *)(void *anchor, void *edx, float *outRect);
 // FUN_REGION_TEXCOORD_CROP — __thiscall(region, float rect[4]) (rect in/out).
 using Crop_t = void(__fastcall *)(void *region, void *edx, float *rect);
 
-// UI coordinate units → internal layout space (the same conversion
-// Tooltip::LinePool applies before calling engine SetPoint; inverse of
-// FontString::Metrics's InternalToPixel).
+// 1024-normalized UI pixels → internal layout (anchor) units — the same
+// conversion Tooltip::LinePool applies before calling engine SetPoint. A
+// region's LOCAL pixels must be folded through its effective scale (+0x7C)
+// before this factor applies; WriteCorners does that.
 float PixelToInternal(float px) {
     const float mul = *reinterpret_cast<const float *>(Offsets::VAR_UI_COORD_SCALE_MUL);
     const float div = *reinterpret_cast<const float *>(Offsets::VAR_UI_COORD_SCALE_DIV);
     if (div == 0.0f)
         return 0.0f;
     return px * mul / (div * Offsets::UI_COORD_SCALE_UNIT);
-}
-float InternalToPixel(float v) {
-    const float mul = *reinterpret_cast<const float *>(Offsets::VAR_UI_COORD_SCALE_MUL);
-    const float div = *reinterpret_cast<const float *>(Offsets::VAR_UI_COORD_SCALE_DIV);
-    if (mul == 0.0f)
-        return 0.0f;
-    return v * div * Offsets::UI_COORD_SCALE_UNIT / mul;
 }
 
 // Retail vertex index → our +0xD4 corner slot (BL=0, TL=1, BR=2, TR=3). The
@@ -113,21 +108,61 @@ int VertexSlot(int vertexIndex) {
 // Given the region's axis-aligned edges, compute the four transformed corner
 // positions (rotate about the pivot, then add the per-corner offsets) and write
 // them to region+0xD4. Corner order: BL, TL, BR, TR.
+//
+// The corner/anchor space is Y-DOWN — a box's rect reads top NUMERICALLY
+// SMALLER than bottom (verified in-game via the GetCorners probe: t=0.222,
+// b=0.277). Two consequences the math below encodes:
+//   - the retail contract is "positive angle = counter-clockwise ON SCREEN",
+//     which lands CCW through the mirrored-partner store below with the
+//     y-down-transposed rotation matrix (settled by a rotated-bar fixture:
+//     the standard matrix rendered clockwise);
+//   - the retail contract is "+offsetY = up on screen", which is numerically
+//     NEGATIVE here.
+// Offsets are stored in the caller's LOCAL pixels and converted at write time:
+// PixelToInternal maps 1024-normalized UI pixels to anchor units, so the
+// region's live effective-scale chain (+0x7C) folds local px into that space
+// first. Without it a region scaled 0.9 got every offset 1/0.9 too large
+// (verified in-game: a 24px offset landed at 26.7px). Reading the scale at
+// write time keeps offsets correct across later scale changes.
 void WriteCorners(void *region, float left, float right, float top, float bottom,
                   const Xf &xf) {
     const float cx = left + xf.cxN * (right - left);
     const float cy = bottom + xf.cyN * (top - bottom);
     const float c = std::cos(xf.angle);
     const float s = std::sin(xf.angle);
+    float scale = *reinterpret_cast<const float *>(
+        reinterpret_cast<const char *>(region) + Offsets::OFF_REGION_EFFECTIVE_SCALE);
+    if (!(scale > 0.0f))
+        scale = 1.0f;
     const float xs[4] = {left, left, right, right};
     const float ys[4] = {bottom, top, bottom, top};
     float *base = reinterpret_cast<float *>(
         reinterpret_cast<char *>(region) + Offsets::OFF_SIMPLETEXTURE_CORNERS);
+    // Compute each corner's TARGET rect-space position first.
+    float tx[4], ty[4];
     for (int i = 0; i < 4; ++i) {
         const float dx = xs[i] - cx;
         const float dy = ys[i] - cy;
-        base[i * 3 + 0] = cx + dx * c - dy * s + xf.offX[i]; // x
-        base[i * 3 + 1] = cy + dx * s + dy * c + xf.offY[i]; // y
+        tx[i] = cx + dx * c + dy * s + PixelToInternal(xf.offX[i] * scale);
+        ty[i] = cy - dx * s + dy * c - PixelToInternal(xf.offY[i] * scale);
+    }
+    // The draw consumes this array with y INVERTED about the rect's horizontal
+    // midline (a vertex stored at rect-space y renders at (top+bottom)-y), and
+    // it CULLS a quad whose slot parity flips (mirroring values in place made
+    // every fixture vanish -- inverted winding). Both established empirically
+    // via the 2026-08-18 texprobe fixture series: offset quads rendered as
+    // exact y-mirrors of their stored corners, the engine's own axis-aligned
+    // stores being mirror-invariant as a point set is what kept it invisible
+    // for plain rects and rotated squares. So each corner's mirrored data is
+    // written into its VERTICAL PARTNER's slot (BL<->TL, BR<->TR): positions
+    // land on target after the draw's flip, and the slot y-parity stays the
+    // engine's, keeping the winding it draws. For an axis-aligned rect this
+    // degenerates to exactly what the engine itself writes.
+    const float mid = top + bottom;
+    for (int i = 0; i < 4; ++i) {
+        const int p = i ^ 1; // vertical partner slot
+        base[i * 3 + 0] = tx[p];
+        base[i * 3 + 1] = mid - ty[p];
         // z (base[i*3 + 2]) is left at 0 — the store/ctor already zeroed it.
     }
 }
@@ -233,8 +268,8 @@ int __fastcall Script_SetVertexOffset(void *L) {
                          ? static_cast<float>(Game::Lua::ToNumber(L, 4))
                          : 0.0f;
     Xf xf = Current(tex);
-    xf.offX[slot] = PixelToInternal(ox);
-    xf.offY[slot] = PixelToInternal(oy);
+    xf.offX[slot] = ox;
+    xf.offY[slot] = oy;
     UpdateAndApply(tex, xf);
     return 0;
 }
@@ -251,8 +286,8 @@ int __fastcall Script_GetVertexOffset(void *L) {
         return 0;
     }
     const Xf xf = Current(tex);
-    Game::Lua::PushNumber(L, InternalToPixel(xf.offX[slot]));
-    Game::Lua::PushNumber(L, InternalToPixel(xf.offY[slot]));
+    Game::Lua::PushNumber(L, xf.offX[slot]);
+    Game::Lua::PushNumber(L, xf.offY[slot]);
     return 2;
 }
 


### PR DESCRIPTION
SetVertexOffset/SetRotation corner writes were wrong in four coupled ways (details in the fix commit):

Units — offsets converted px→anchor with the global 1024-normalized factor only; a region scaled 0.9 got every offset 1/0.9 too large (24px request measured at 26.67px via a corner-array readback). Offsets now store the caller's local pixels and fold through the region's live effective scale (+0x7C) at write time — verified landing at 24.00px at two scale points (0.9, 0.45).
Y-direction — the anchor space is y-down (rect reads t=0.222 < b=0.277), so retail's "+offsetY = up" is numerically negative there; it was added positive.
Store contract — the draw consumes +0xD4 with y inverted about the rect midline and culls a quad whose slot parity flips. Corners are now written mirrored into their vertical partner's slot (BL↔TL, BR↔TR); for an axis-aligned rect this degenerates to exactly what the engine writes itself, which is why the inversion was invisible on plain rects and rotated squares (mirror-invariant point sets).
Chirality — with that store contract, the y-down-transposed rotation matrix is the one that renders positive angles counter-clockwise (verified with a rotated-bar fixture; squares are direction-blind).
Only regions with an active transform are affected — the co-hook passes untracked regions through unchanged. Found while building a WeakAuras-style radial cooldown spiral on the corner transforms; fixture screenshots available on request. Second commit adds texture:GetCorners(), the raw-corner debug readback the diagnosis was done with — happy to drop it from the PR if you'd rather keep the API surface clean.

Second commit is just a debug binding. Feel free to just revert that if you dont want it in.