### PR TITLE
fix(texture): measure vertex offsets against the untouched layout rect

### DIFF
--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -374,10 +374,22 @@ enum Offsets {
     FUN_REGION_STORE_CORNERS = 0x007705B0,
     // Texcoord crop applied to a {top,left,bottom,right} screen rect before the
     // corner-store: shrinks right→left and bottom→top by the region's per-corner
-    // texcoord span (ABS of the +0x104 U/V differences), so a partial SetTexCoord
-    // draws a smaller quad. No-op for full 0..1 texcoords. `__thiscall(region,
-    // float rect[4])`, rect in/out.
+    // texcoord span (ABS of the +0x104 U/V differences). No-op for full 0..1
+    // texcoords. `__thiscall(region, float rect[4])`, rect in/out. The crop
+    // itself is unconditional; every engine call site gates it on
+    // OFF_REGION_TEXCOORD_MODIFIES_RECT below — with the flag clear (the
+    // default) a partial SetTexCoord draws at the region's FULL size, so
+    // callers replicating an engine store must apply the same gate.
     FUN_REGION_TEXCOORD_CROP = 0x00770570,
+    // The SetTexCoordModifiesRect flag (int). Written from the Lua boolean by
+    // Script_SetTexCoordModifiesRect (0x0079C080, `piVar4[0x49]`), read back
+    // 1/nil by Script_GetTexCoordModifiesRect (0x0079C120). All three
+    // FUN_REGION_TEXCOORD_CROP call sites test it: the SetTexCoord writers
+    // (FUN_00770410 4-arg, FUN_007704C0 8-arg corner form) crop+store only
+    // when set, and the layout-resolve store path (FUN_00770670) crops when
+    // set / stores the raw anchor rect (+0x40..+0x4C) when clear. Zero by
+    // default (region ctor), so the crop never runs unless an addon opts in.
+    OFF_REGION_TEXCOORD_MODIFIES_RECT = 0x124,
     // Get the region's resolved screen rect: `__thiscall(region+OFF_REGION_ANCHOR,
     // float out[4]) -> int` (1 = valid, 0 = not laid out yet). Reads the anchor
     // sub-object's +0x40..+0x4C = {top, left, bottom, right}, gated on the

--- a/src/texture/Transform.cpp
+++ b/src/texture/Transform.cpp
@@ -28,8 +28,9 @@
 // A transform composes with the 8-argument corner form of SetTexCoord, which is
 // how a caller warps the SHAPE and says what each moved corner SAMPLES in one
 // paired write (WeakAuras' radial wedges are built this way). That only holds
-// because the offsets are measured against the region's untouched layout rect —
-// see the note in ApplyFromRect.
+// because the offsets are measured against the same rect the engine's own store
+// uses — the untouched layout rect, unless the region opted into
+// SetTexCoordModifiesRect — see the note in ApplyFromRect.
 //
 // Units: rotation is scale-invariant, but a vertex offset has a magnitude. The
 // Lua offset is in the texture's LOCAL pixels (like SetPoint's x/y), stored
@@ -85,6 +86,8 @@ StoreCorners_t g_storeOriginal = nullptr;
 
 // FUN_REGION_GET_RECT — __thiscall(region+OFF_REGION_ANCHOR, float out[4]) -> int.
 using GetRect_t = int(__fastcall *)(void *anchor, void *edx, float *outRect);
+// FUN_REGION_TEXCOORD_CROP — __thiscall(region, float rect[4]) (rect in/out).
+using Crop_t = void(__fastcall *)(void *region, void *edx, float *rect);
 
 // 1024-normalized UI pixels → internal layout (anchor) units — the same
 // conversion Tooltip::LinePool applies before calling engine SetPoint. A
@@ -184,17 +187,26 @@ bool ApplyFromRect(void *region, const Xf &xf) {
     if (reinterpret_cast<GetRect_t>(Offsets::FUN_REGION_GET_RECT)(anchor, nullptr,
                                                                   rect) == 0)
         return false;
-    // The texcoord crop (FUN_REGION_TEXCOORD_CROP) is deliberately NOT applied
-    // here. The engine gates it on the region's SetTexCoordModifiesRect flag,
-    // which is off by default, so a plain texture with a partial or
-    // corner-form texcoord draws at its FULL size — verified in-game against
-    // .25-span, inset, sheared and wedge-shaped corner texcoords, every one of
-    // which left the drawn quad untouched. Calling it directly bypassed that
-    // gate, so a region carrying both a transform and a partial texcoord had
-    // its offsets measured against a shrunken rect: WeakAuras-style radial
-    // wedges, whose texcoords and vertex offsets are one paired corner move,
-    // collapsed onto the rect's edge (a 64px wedge that should have spanned
-    // x = 0.5..1 of its region landed entirely on x = 0.5).
+    // Apply the texcoord crop (FUN_REGION_TEXCOORD_CROP) exactly as the
+    // engine's own store paths do: gated on the region's
+    // SetTexCoordModifiesRect flag (+0x124), which is off by default. With the
+    // flag clear, a plain texture with a partial or corner-form texcoord draws
+    // at its FULL size — verified in-game against .25-span, inset, sheared and
+    // wedge-shaped corner texcoords, every one of which left the drawn quad
+    // untouched — and the layout-resolve store (FUN_00770670) feeds the raw
+    // anchor rect to the corner store. Calling the crop UNCONDITIONALLY here
+    // bypassed that gate, so a region carrying both a transform and a partial
+    // texcoord had its offsets measured against a shrunken rect the engine
+    // never used: WeakAuras-style radial wedges, whose texcoords and vertex
+    // offsets are one paired corner move, collapsed onto the rect's edge (a
+    // 64px wedge that should have spanned x = 0.5..1 of its region landed
+    // entirely on x = 0.5). Keeping the flag-gated call matches the engine in
+    // BOTH states, so this immediate apply and the corner-store co-hook below
+    // (which re-derives edges from whatever rect the engine stored) can never
+    // disagree about the base rect.
+    if (*reinterpret_cast<const int *>(reinterpret_cast<char *>(region) +
+                                       Offsets::OFF_REGION_TEXCOORD_MODIFIES_RECT) != 0)
+        reinterpret_cast<Crop_t>(Offsets::FUN_REGION_TEXCOORD_CROP)(region, nullptr, rect);
     // rect = {top, left, bottom, right}
     WriteCorners(region, rect[1], rect[3], rect[0], rect[2], xf);
     return true;

--- a/src/texture/Transform.cpp
+++ b/src/texture/Transform.cpp
@@ -25,6 +25,12 @@
 // transform is written once and costs nothing per frame; a moving/resizing
 // region re-transforms automatically.
 //
+// A transform composes with the 8-argument corner form of SetTexCoord, which is
+// how a caller warps the SHAPE and says what each moved corner SAMPLES in one
+// paired write (WeakAuras' radial wedges are built this way). That only holds
+// because the offsets are measured against the region's untouched layout rect —
+// see the note in ApplyFromRect.
+//
 // Units: rotation is scale-invariant, but a vertex offset has a magnitude. The
 // Lua offset is in the texture's LOCAL pixels (like SetPoint's x/y), stored
 // raw, and converted to the engine's internal layout space inside WriteCorners
@@ -79,8 +85,6 @@ StoreCorners_t g_storeOriginal = nullptr;
 
 // FUN_REGION_GET_RECT — __thiscall(region+OFF_REGION_ANCHOR, float out[4]) -> int.
 using GetRect_t = int(__fastcall *)(void *anchor, void *edx, float *outRect);
-// FUN_REGION_TEXCOORD_CROP — __thiscall(region, float rect[4]) (rect in/out).
-using Crop_t = void(__fastcall *)(void *region, void *edx, float *rect);
 
 // 1024-normalized UI pixels → internal layout (anchor) units — the same
 // conversion Tooltip::LinePool applies before calling engine SetPoint. A
@@ -180,7 +184,17 @@ bool ApplyFromRect(void *region, const Xf &xf) {
     if (reinterpret_cast<GetRect_t>(Offsets::FUN_REGION_GET_RECT)(anchor, nullptr,
                                                                   rect) == 0)
         return false;
-    reinterpret_cast<Crop_t>(Offsets::FUN_REGION_TEXCOORD_CROP)(region, nullptr, rect);
+    // The texcoord crop (FUN_REGION_TEXCOORD_CROP) is deliberately NOT applied
+    // here. The engine gates it on the region's SetTexCoordModifiesRect flag,
+    // which is off by default, so a plain texture with a partial or
+    // corner-form texcoord draws at its FULL size — verified in-game against
+    // .25-span, inset, sheared and wedge-shaped corner texcoords, every one of
+    // which left the drawn quad untouched. Calling it directly bypassed that
+    // gate, so a region carrying both a transform and a partial texcoord had
+    // its offsets measured against a shrunken rect: WeakAuras-style radial
+    // wedges, whose texcoords and vertex offsets are one paired corner move,
+    // collapsed onto the rect's edge (a 64px wedge that should have spanned
+    // x = 0.5..1 of its region landed entirely on x = 0.5).
     // rect = {top, left, bottom, right}
     WriteCorners(region, rect[1], rect[3], rect[0], rect[2], xf);
     return true;


### PR DESCRIPTION
## fix(texture): measure vertex offsets against the untouched layout rect

`Texture:SetVertexOffset` / `SetRotation` compute the drawn quad in
`ApplyFromRect`, which read the region's layout rect and then passed it
through `FUN_REGION_TEXCOORD_CROP` before writing corners. That call is
removed.

### Why the engine's own crop must not be applied here

`FUN_REGION_TEXCOORD_CROP` shrinks a region's drawn rect by its texcoord
span, but the engine only reaches it behind the region's
`SetTexCoordModifiesRect` flag, which is **off by default**. Probed on a
live 1.12 client: a plain texture given a `.25`-span corner texcoord, an
inset `.25–.75` texcoord, a sheared one (a single corner pulled to `u=.5`
at full bounding span), and a full wedge-shaped set all draw at the
region's **full** size. `GetTexCoordModifiesRect` reads nil and toggling
it changes nothing. So an untransformed texture with a partial texcoord is
never cropped.

Calling the crop directly bypassed that gate. The result was that a region
carrying **both** a transform and a partial texcoord had its offsets
measured against a rect the engine itself would never have shrunk — the
transform and the texcoords became two writers of one quad.

### Why that matters

The 8-argument corner form of `SetTexCoord` plus `SetVertexOffset` is a
single paired corner move: the offset places the corner, the texcoord says
what it samples. With the crop applied, every
wedge whose texcoords span less than the whole art collapsed.

Measured on a 64px region, foreground wedge 0°–135°, whose corner offsets
are UL +32, LL +32, UR 0, LR 0 px:

| base rect | resulting drawn x |
| --- | --- |
| the region's true rect | `{0.5, 0.5, 1, 1}` — the correct wedge |
| cropped to half width | `{0.5, 0.5, 0.5, 0.5}` — collapsed to the edge |
| **what the client drew** | **`{0.500, 0.500, 0.501, 0.501}`** |

Read off `Texture:GetCorners()`, normalized to the region's own rect.
Wedges whose deciding texcoord edge happened to span the full art were
unaffected, which is why the artifact looked erratic rather than total:
in a three-texture spinner the background quad rendered correctly while
the foreground quad collapsed into a small solid shape near the centre.

### Relationship to #26

Independent. #26 corrected the offset units (missing effective scale), the
y direction, and the mirrored-partner corner-store contract; this call
predates it, arriving with the original backport in #24, and #26 left it
as context. #26 is what made the defect *reachable* — before it, offsets
were wrong for several reasons at once, so no correct wedge could be drawn
to expose the base-rect problem.

### Risk

Behaviour changes only for a region that has a transform **and** a partial
texcoord — previously broken, since its offsets were scaled against an
arbitrary rect that varied with the texcoords. A transform on a full-span
texcoord (the common case: rotation, slanted bars) is unaffected: the crop
is a no-op at full span. The now-unused `Crop_t` alias is dropped.

Verified in-game: circular progress textures and a radial cooldown swipe
draw correctly through both sweep directions, partial arcs, static holds
and inverse, on 40–200px regions.
<img width="879" height="184" alt="grafik" src="https://github.com/user-attachments/assets/490bdab6-32a5-4564-8620-a8590549758b" />
