### PR TITLE
fix(aura): scope polarity flags to Turtle clients

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5734,8 +5734,8 @@ go to a different resolver and won't match).
 
 Unified-aura method. `index` is in the same `HELPFUL` / `HARMFUL` index
 space as `C_UnitAuras.GetAuraDataByIndex`, so an index you got from
-`C_UnitAuras` always opens the matching tooltip. That includes a debuff
-that the server parked in a buff slot. The tooltip itself comes from the
+`C_UnitAuras` always opens the matching tooltip. On Turtle, that includes a
+debuff the server parked in a buff slot. The tooltip itself comes from the
 engine's own `SetUnitBuff` or `SetUnitDebuff`. `filter` defaults to
 helpful when omitted. Only its `HELPFUL` or `HARMFUL` token is read, so
 pass an index from the same plain list.
@@ -15974,13 +15974,12 @@ Backport of the `C_UnitAuras` namespace. Returns
 
 Reads primarily off the unit's `m_objectFields` descriptor — same
 data source `UnitBuff` / `UnitDebuff` use. The descriptor has 48 aura
-slots. The server seats buffs in slots 0 to 31 and debuffs in slots 32
-to 47 while it can. When the 16 debuff slots are full, it puts further
-debuffs into free buff slots. Each slot also carries a flag that records
-the aura's real polarity, and `HELPFUL` / `HARMFUL` select on that flag.
-So a debuff that sits in a buff slot is still a debuff here. The native
-`UnitBuff` / `UnitDebuff` split by slot range and report such a debuff as
-a buff. Indices are stable in the normal case: a `HARMFUL` walk visits
+slots. Under normal 1.12.1 semantics, buffs occupy slots 0 to 31 and
+debuffs occupy slots 32 to 47, so `HELPFUL` / `HARMFUL` classify by that
+range. Turtle extends the layout: excess debuffs can spill into free buff
+slots, with their real polarity recorded in the per-slot flag nibble. On
+Turtle, `HELPFUL` / `HARMFUL` therefore select on that polarity flag. Indices
+are stable in the normal case: a `HARMFUL` walk visits
 slots 32 to 47 first, then any spilled debuffs in 0 to 31.
 
 When a party/raid member has **no live unit object at all** (a
@@ -15998,8 +15997,8 @@ these functions surface them, exactly as the built-in `UnitBuff` /
 | `applications` | number | stack count (engine stores `stacks-1`, we display `+1`) |
 | `spellId` | number | spell ID from the descriptor's aura array |
 | `dispelName` | string | `"Magic"` / `"Curse"` / `"Disease"` / `"Poison"` (from `SpellDispelType.dbc`), or `""` if non-dispellable |
-| `isHelpful` | boolean | true when the slot's polarity flag marks the aura positive |
-| `isHarmful` | boolean | true when the slot's polarity flag marks the aura negative. Read from the flag, not the slot number, so a debuff parked in a buff slot reads harmful |
+| `isHelpful` | boolean | true when the aura is helpful: by fixed slot range normally, or Turtle polarity flag on Turtle |
+| `isHarmful` | boolean | true when the aura is harmful: by fixed slot range normally, or Turtle polarity flag on Turtle (including spilled debuffs) |
 | `duration` | number | applied duration in seconds. When the aura's cast was observed (in the `Aura::Source` cache), this is the caster-modified duration — talent/glyph extensions like Improved Shadow Word: Pain included — so it stays consistent with `expirationTime` (`remaining ≤ duration`). On a cache miss it falls back to the base `Spell.dbc → SpellDuration.dbc` value with level scaling. Returns 0 for spells flagged "no duration" (passives, paladin auras, infinite buffs) |
 | `expirationTime` | number | for `unit == "player"`, read from the engine's player-buff table at `0x00BC6040` (same data `GetPlayerBuffTimeLeft` returns). For any other unit, taken from the `Aura::Source` cache (cast time + duration captured from `SMSG_SPELL_GO`; see below). `0` when neither source has it. `expirationTime - GetTime()` gives the true remaining time |
 | `sourceUnit` | string | unit token of the caster (`"player"`, `"raid7"`, `"nameplate1"`, …), resolved from the `Aura::Source` cache. `nil` if the cast wasn't observed or the caster maps to no current token |
@@ -16016,8 +16015,9 @@ The optional `filter` string is a pipe-separated set of upper-case
 tokens (`"HELPFUL"`, `"HARMFUL"`,
 `"HELPFUL|PLAYER"`, etc.). Honored:
 
-- **`HELPFUL`** (default) / **`HARMFUL`** — pick buffs or debuffs by each
-  aura's polarity flag. In `GetUnitAuras`, supplying neither returns both.
+- **`HELPFUL`** (default) / **`HARMFUL`** — pick buffs or debuffs by the
+  normal 1.12.1 slot range, or by Turtle's polarity flag on Turtle. In
+  `GetUnitAuras`, supplying neither returns both.
 - **`PLAYER`** — restrict to auras the local player cast, via the
   `Aura::Source` caster cache (`sourceGUID == ` player GUID). Combines with
   the range tokens (`"HARMFUL|PLAYER"` = your debuffs only). Because the
@@ -16123,9 +16123,9 @@ end
 separated by `|` or spaces, each token optionally negated with a
 leading `!`. This build honors:
 
-- `HELPFUL` / `HARMFUL` — buffs / debuffs, by each aura's polarity flag
-  rather than its slot number. With neither token the query returns both
-  (the indexed getter defaults to helpful).
+- `HELPFUL` / `HARMFUL` — buffs / debuffs, by the normal 1.12.1 slot
+  range or by Turtle's polarity flag on Turtle. With neither token the query
+  returns both (the indexed getter defaults to helpful).
 - `PLAYER` / `!PLAYER` — only auras the local player cast, or only
   auras the player did not cast. Caster data comes from casts this
   session, so an aura present before you saw it cast has no caster and

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -1488,10 +1488,10 @@ enum Offsets {
     //                and gate on `(nibble & 0x0E) != 0` (visibility)
     //   Both read stacks at desc[+0x1AC + slot] and display as `byte + 1`
     //
-    // For our purposes we don't decode individual flag bits — we
-    // distinguish helpful vs harmful by absolute slot range, and we
-    // derive `dispelName` from `Spell.dbc[+0x10]` (see
-    // `OFF_SPELL_DISPEL_TYPE` below), not from the flags nibble.
+    // Aura visibility always uses the descriptor nibble. Polarity uses the
+    // fixed slot range under normal 1.12.1 semantics; Turtle's extension uses
+    // dedicated nibble bits so harmful auras can spill into helpful slots.
+    // `dispelName` comes from `Spell.dbc[+0x10]` (see OFF_SPELL_DISPEL_TYPE).
     OFF_UNIT_FIELD_AURA = 0xA4,                // u32 spell ID per slot, 48 slots total
     // UNIT_AURA event id for FUN_UNIT_EVENT_BROADCAST. The per-token unit
     // events use field-index == event-id; the aura field is index 0x29
@@ -1504,13 +1504,10 @@ enum Offsets {
     UNIT_AURA_DEBUFF_COUNT = 16,               // slot range 32..47 (harmful)
     UNIT_AURA_TOTAL = 48,
     UNIT_AURA_VISIBLE_MASK = 0x0E,             // nibble mask used by the engine's visibility gate
-    // Per-slot flag nibble bits as the server writes them (tortoise-wow
-    // SpellAuraHolder::SetAuraFlag, verified): a positive aura gets HELPFUL
-    // (+ CANCELABLE unless SPELL_ATTR_CANT_CANCEL), a negative aura gets
-    // HARMFUL. This is the aura's real polarity. The slot range is only where
-    // the server preferred to seat it — once the 16 debuff slots are full it
-    // parks further debuffs in 0..31 (and sets UNIT_FLAG_AURAS_VISIBLE so the
-    // client renders them), so a slot number alone misreads those.
+    // Turtle's per-slot polarity bits (tortoise-wow SpellAuraHolder::SetAuraFlag,
+    // verified): positive = 0x04, negative = 0x08. These are Turtle semantics,
+    // not stock 1.12.1 aura-flag semantics; non-Turtle polarity is determined
+    // by the fixed 0..31 helpful / 32..47 harmful slot ranges.
     UNIT_AURA_FLAG_CANCELABLE = 0x01,
     UNIT_AURA_FLAG_HELPFUL = 0x04,
     UNIT_AURA_FLAG_HARMFUL = 0x08,

--- a/src/aura/Api.cpp
+++ b/src/aura/Api.cpp
@@ -21,9 +21,8 @@
 // tokens separated by `|` and/or whitespace, each optionally negated with a
 // leading `!`. Whole-token matching, so `RAID_PLAYER_DISPELLABLE` is not
 // mistaken for `PLAYER` and `!PLAYER` is a negation rather than a match.
-// Honored: `HELPFUL` / `HARMFUL` (the aura's flag-nibble polarity — see
-// Data.h; NOT the slot range, which misreads debuffs spilled into buff
-// slots), `PLAYER` /
+// Honored: `HELPFUL` / `HARMFUL` (normal 1.12.1 slot-range polarity, or
+// Turtle's flag-nibble polarity when Turtle is detected — see Data.h), `PLAYER` /
 // `!PLAYER` (caster == / != the local player, from the Aura::Source cache),
 // `DISPELLABLE` / `!DISPELLABLE` (dispel type is / isn't one a
 // dispel/purge/steal can remove — Spell.dbc Dispel ∈ Magic/Curse/Disease/

--- a/src/aura/Data.cpp
+++ b/src/aura/Data.cpp
@@ -22,6 +22,7 @@
 #include "spell/CrowdControl.h"
 #include "spell/IsSelfBuff.h"
 #include "time/Clock.h"
+#include "turtle/Detect.h"
 #include "unit/Identity.h"
 
 #include <cstdint>
@@ -275,6 +276,15 @@ bool IsSlotPopulated(const uint8_t *unit, int slot) {
 bool IsSlotHarmful(const uint8_t *unit, int slot) {
     if (slot < 0 || slot >= Offsets::UNIT_AURA_TOTAL)
         return false;
+
+    // Stock 1.12.1 aura polarity is encoded by the descriptor slot range:
+    // helpful 0..31, harmful 32..47. Turtle extends that layout by parking
+    // excess harmful auras in helpful slots and records their real polarity
+    // in the per-slot flag nibble, so only Turtle should interpret 0x04/0x08
+    // as helpful/harmful flags.
+    if (!Turtle::Detected())
+        return slot >= Offsets::UNIT_AURA_BUFF_COUNT;
+
     auto *desc = Descriptor(unit);
     if (desc == nullptr)
         return false;
@@ -307,9 +317,9 @@ bool IsSlotTooltipVisible(const uint8_t *unit, int slot) {
 }
 
 int SlotInFilterOrder(Filter filter, int i) {
-    // Harmful: 32..47 first, then 0..31 (where the server parks debuffs once
-    // the 16 are full). Helpful: 0..31 then 32..47 — positive auras never
-    // spill downward in practice, so that tail is a no-op safety net.
+    // Harmful: 32..47 first, then 0..31 (where Turtle can park excess
+    // debuffs). Helpful: 0..31 then 32..47. On normal 1.12.1 semantics
+    // IsSlotHarmful filters the opposite range, so the second pass is a no-op.
     if (filter == Filter::Harmful)
         return (i + Offsets::UNIT_AURA_BUFF_COUNT) % Offsets::UNIT_AURA_TOTAL;
     return i;
@@ -713,7 +723,7 @@ static Attribution CachedAttribution(const Aura::Source::CachedAura &c) {
 
 void Push(void *L, const uint8_t *unit, int slot, Emit emit) {
     const uint32_t spellID = ReadSpellID(unit, slot);
-    const bool isHelpful = !IsSlotHarmful(unit, slot); // nibble, not slot range
+    const bool isHelpful = !IsSlotHarmful(unit, slot); // flavor-aware polarity
     const int unitLevel = (unit != nullptr) ? PlayerLevel(unit) : 0;
     PushEnriched(L, UnitGuid(unit), spellID, isHelpful, ReadStacks(unit, slot),
                  unitLevel, unit != nullptr && unit == LocalPlayer(), slot,

--- a/src/aura/Data.h
+++ b/src/aura/Data.h
@@ -20,25 +20,22 @@
 // `unit + OFF_CGUNIT_OBJECT_FIELDS`; the layout is documented in
 // `Offsets.h` under `OFF_UNIT_FIELD_AURA*`.
 //
-// Slots are absolute 0..47. The server SEATS positive auras in 0..31 and
-// negative ones in 32..47, but that is a preference, not a rule: once the 16
-// debuff slots are full it parks further debuffs in 0..31 (and sets
-// UNIT_FLAG_AURAS_VISIBLE so the client renders them). An aura's real polarity
-// is the per-slot flag nibble (UNIT_AURA_FLAG_HELPFUL / _HARMFUL), which the
-// server writes for every visible aura — that is what `Filter` selects on
-// here. The engine's own UnitBuff/UnitDebuff split by slot range and so report
-// a spilled debuff as a buff; that is a 1.12 UI limitation we deliberately do
-// not mirror (retail's contract is the aura's actual polarity). A polarity
-// walk visits its home range first, then the other range, so indices stay
-// exactly what they were in the common no-spill case.
+// Slots are absolute 0..47. Normal 1.12.1 semantics use 0..31 for helpful
+// auras and 32..47 for harmful auras, so the slot range is the polarity. Turtle
+// extends that layout by parking excess harmful auras in 0..31 and uses the
+// per-slot 0x04/0x08 flag nibble to preserve their real polarity. `Filter`
+// therefore classifies by slot range normally and by the Turtle polarity flag
+// when Turtle is detected. A polarity walk still visits its home range first,
+// then the other range, so indices stay unchanged in the common no-spill case.
 //
 // Callers that take a 1-based Lua index into "buffs" or "debuffs" translate
 // to the absolute 0..47 slot before calling in.
 
 namespace Aura::Data {
 
-// Filter for slot iteration: the aura's polarity per its flag nibble (see the
-// file header). The engine's `UnitBuff` / `UnitDebuff` pick one direction;
+// Filter for slot iteration: the aura's polarity per its normal slot range or,
+// on Turtle, its polarity flag nibble (see the file header). The engine's
+// `UnitBuff` / `UnitDebuff` pick one direction;
 // modern `C_UnitAuras.GetAuraDataByIndex` defaults to helpful when no filter
 // is specified.
 enum class Filter { Helpful, Harmful };
@@ -93,9 +90,9 @@ uint32_t ReadSpellID(const uint8_t *unit, int slot);
 // to decide whether to surface an aura through Lua.
 bool IsSlotPopulated(const uint8_t *unit, int slot);
 
-// The aura's polarity from its flag nibble: true iff the slot carries
-// UNIT_AURA_FLAG_HARMFUL. False for an empty slot or a null unit. This, not
-// the slot range, is what `Filter` selects on (see the file header).
+// The aura's polarity. Normal 1.12.1 semantics use the fixed slot range;
+// Turtle uses UNIT_AURA_FLAG_HARMFUL so harmful auras can spill into 0..31.
+// False for an invalid slot (and, on Turtle, a null unit).
 bool IsSlotHarmful(const uint8_t *unit, int slot);
 
 // The engine's TOOLTIP visibility gate for a slot: occupied, visible nibble,
@@ -107,7 +104,7 @@ bool IsSlotTooltipVisible(const uint8_t *unit, int slot);
 
 // The i-th slot (0..UNIT_AURA_TOTAL-1) in the order a `filter` walk visits the
 // descriptor: the polarity's home range first (helpful 0..31, harmful 32..47),
-// then the other range, where spilled debuffs live. Every enumeration that
+// then the other range, where Turtle may expose spilled debuffs. Every enumeration that
 // hands out indices or slot lists uses this so they agree on order.
 int SlotInFilterOrder(Filter filter, int i);
 

--- a/src/aura/Source.cpp
+++ b/src/aura/Source.cpp
@@ -1515,10 +1515,9 @@ const Net::PacketDispatch::AutoSubscribe _spellGoSub{&SpellGoSub};
 
 // ---- Aura-application co-hooks (timing for proc / triggered auras) -------
 
-// Classify by the slot's flag nibble (UNIT_AURA_FLAG_HARMFUL), not its range:
-// the server parks debuffs in buff slots once the 16 are full, and the nibble
-// is what records their real polarity. The descriptor write pass has already
-// landed the flags when the application hooks fire (see Aura::Data).
+// Classify through Aura::Data so this cache follows the same flavor-aware
+// polarity rule as C_UnitAuras: fixed slot ranges normally, Turtle's polarity
+// nibble when Turtle is detected (required for Turtle's spilled debuffs).
 int8_t KindForSlot(const void *unit, int slot) {
     return Aura::Data::IsSlotHarmful(static_cast<const uint8_t *>(unit), slot)
                ? KIND_HARMFUL


### PR DESCRIPTION
This fixes a regression introduced by the switch to flag-based aura polarity.

On a non-Turtle 1.12.1 client, `C_UnitAuras` can currently classify normal helpful auras as harmful. For example, on SoloCraft with only Sanctity Aura active:

```lua
/script a=C_UnitAuras.GetAuraDataByIndex("player",1,"HARMFUL");DEFAULT_CHAT_FRAME:AddMessage(a and a.name or "nil")
```

currently returns:

```text
Sanctity Aura
```

The issue is that the `0x04` / `0x08` aura flag interpretation used by the new polarity handling is Turtle-specific.

Turtle's server changes use those bits to record positive/negative polarity and allow harmful auras beyond the normal 16 debuff slots to spill into the 0–31 range.

Under normal 1.12.1 aura semantics, polarity remains determined by the fixed descriptor ranges:

* slots 0–31: helpful
* slots 32–47: harmful

The corresponding aura flag bits are not polarity bits there, so interpreting `0x08` globally as harmful can misclassify normal buffs.

This change uses ClassicAPI's existing `Turtle::Detected()` handling to select the appropriate semantics:

* Turtle: retain the existing flag-based polarity handling and debuff spillover support.
* Non-Turtle: classify polarity using the normal 1.12.1 slot ranges.

The Turtle path itself is otherwise unchanged.

The related comments and API documentation have also been updated so Turtle's extended aura behaviour is no longer described as universal 1.12.1 behaviour.
